### PR TITLE
Prevent recursive run of service.sh file

### DIFF
--- a/Detach.txt
+++ b/Detach.txt
@@ -9,7 +9,7 @@
 #Hangouts 
 #Phone 
 #Photos 
-YouTube
+#YouTube
 #YouTube Music
 #Gboard 
 #Clock 

--- a/Detach.txt
+++ b/Detach.txt
@@ -1,0 +1,45 @@
+ - Detach Market Apps Configuration -
+
+ - Remove comment (#) to detach an App.
+ 
+#Contacts 
+#Gmail 
+#Google App 
+#Google Plus 
+#Hangouts 
+#Phone 
+#Photos 
+YouTube
+#YouTube Music
+#Gboard 
+#Clock 
+#Camera 
+#Inbox 
+#Duo
+#Dropbox 
+#PushBullet 
+#Calendar 
+#Keep 
+#Telegram 
+#Swiftkey 
+#Translate 
+#Facebook 
+#Pandora 
+#Twitter 
+#Slack 
+#Mega 
+#WhatsApp 
+#Voice 
+#Drive 
+#Netflex 
+#Pixel Launcher 
+#Wallpapers 
+#Capture 
+#Google Connectivity Services 
+#Google VR Services 
+#Google Play Services 
+#Google Carrier Services
+
+
+
+

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ NOTE BEFORE INSTALL: DON'T FLASH THIS MODULE IN TWRP. USE MAGISK MANAGER ONLY TO
 <br />
 
 <b><h3>:scroll: Setup steps:</h3></b>
-- Start by downloading the <a href="https://github.com/xerta555/Detach-Files/raw/master/Detach.txt">Detach.txt</a> file to your `/sdcard/` folder: <a href="https://raw.githubusercontent.com/xerta555/Detach-Files/master/Detach.txt">Detach.txt</a>
+- Start by downloading the <a href="https://raw.githubusercontent.com/sobuj53/Detach/master/Detach.txt">Detach.txt</a> file to your `/sdcard/` folder: <a href="https://raw.githubusercontent.com/sobuj53/Detach/master/Detach.txt">Detach.txt</a>
   - (equivalent to `/storage/emulated/0/`)
 - Uncomment the common app(s) you want in this file
 - Save changes

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ NOTE BEFORE INSTALL: DON'T FLASH THIS MODULE IN TWRP. USE MAGISK MANAGER ONLY TO
 <br />
 
 <b>For common apps:</b>
-- You have to download the `Detach.txt` file: <a href="https://raw.githubusercontent.com/xerta555/Detach-Files/master/Detach.txt">Detach.txt</a>
+- You have to download the `Detach.txt` file: <a href="https://raw.githubusercontent.com/sobuj53/Detach/master/Detach.txt">Detach.txt</a>
 - Save it in your internal storage: `/sdcard/Detach.txt` (quivalent to `/storage/emulated/0/Detach.txt`).
  
 <img src="https://i.ibb.co/X54TnPG/Screenshot-20190923-184536.png" alt="Screenshot-20190815-170758.png" height="1200" width="600">

--- a/appslist.csv
+++ b/appslist.csv
@@ -1,0 +1,37 @@
+com.google.android.gm,Gmail
+com.google.android.googlequicksearchbox,Google
+com.google.android.apps.plus,Google Plus
+com.google.android.talk,Hangouts
+com.google.android.youtube,YouTube
+com.google.android.apps.youtube.music,YouTube Music
+com.google.android.inputmethod.latin,Gboard
+com.google.android.contacts,Contacts
+com.google.android.dialer,Phone
+com.google.android.apps.photos,Photos
+com.google.android.deskclock,Clock
+com.google.android.GoogleCamera,Camera
+com.google.android.apps.inbox,Inbox
+com.google.android.apps.tachyon,Duo
+com.dropbox.android,Dropbox
+com.pushbullet.android,PushBullet
+com.google.android.calendar,Calendar
+com.google.android.keep,Keep
+org.telegram.messenger,Telegram
+com.touchtype.swiftkey,Swiftkey
+com.google.android.apps.translate,Translate
+com.facebook.katana,Facebook
+com.pandora.android,Pandora
+com.twitter.android,Twitter
+com.Slack,Slack
+mega.privacy.android.app,Mega
+com.whatsapp,WhatsApp
+com.google.android.apps.googlevoice,Voice
+com.google.android.apps.docs,Drive
+com.netflix.mediaclient,Netflix
+com.google.android.apps.nexuslauncher,Pixel Launcher
+com.google.android.apps.wallpaper,Wallpapers
+com.gopro.smarty,Capture
+com.google.android.apps.gcs,Google Connectivity Services
+com.google.vr.vrcore,Google VR Services
+com.google.android.gms,Google Play Services
+com.google.android.ims,Google Carrier Services

--- a/compatibility.txt
+++ b/compatibility.txt
@@ -18,7 +18,7 @@ chmod 0777 "$MAGMOD/first_detach_result.txt"
 if [ "$ps_accounts" -gt "1" ]; then
 	test -e "$instant_run_two" || touch "$instant_run_two"
 	chmod 0777 "$instant_run_two"
-	echo -e "PLAY_DB_DIR=/data/data/com.android.vending/databases\nSQLITE=${MAGMOD}\n\n\nam force-stop com.android.vending\n\ncd \$SQLITE\nSleep 1;\n" >> "$instant_run_two"
+	echo -e "PLAY_DB_DIR=/data/data/com.android.vending/databases\nSQLITE=${MAGMOD}\n\n\nam force-stop com.android.vending\n\ncd \$SQLITE\nsleep 1\n" >> "$instant_run_two"
 	am force-stop com.android.vending
 	for i in {1..${ps_accounts_final}}; do sed -n '/^\s*$SQLITE\/sqlite.*/p' "$instant_run" >> "$instant_run_two"; done
 	#sed -i -e "s/.$(echo a | tr 'a' '\t')\/sqlite/\$SQLITE\/sqlite/" "$instant_run_two"

--- a/compatibility.txt
+++ b/compatibility.txt
@@ -1,15 +1,17 @@
+MAGMOD=/data/adb/modules/Detach
+instant_run=$MAGMOD/instant_run.sh
+instant_run_two=$MAGMOD/instant_run_two.sh
+MAGMOD=$MODDIR
 
 # Multiple Play Store accounts compatibility
 ps_accounts=$("$MODDIR/sqlite" $PS_DATA_PATH "SELECT account FROM ownership" | sort -u | wc -l)
 ps_accounts_final=$((ps_accounts+1))
 
-MAGMOD=/data/adb/modules/Detach
-instant_run=$MAGMOD/instant_run.sh
-instant_run_two=$MAGMOD/instant_run_two.sh
-MAGMOD=$MODDIR
 test -e "$MAGMOD/first_detach_result.txt" || touch "$MAGMOD/first_detach_result.txt"
 chmod 0777 "$MAGMOD/first_detach_result.txt"
-sh "$MAGMOD/service.sh" > "$MAGMOD/first_detach_result.txt" 2>&1
+
+#prevent recursive run
+#sh "$MAGMOD/main.sh" > "$MAGMOD/first_detach_result.txt" 2>&1
 
 if [ "$ps_accounts" -gt "1" ]; then
 	test -e "$instant_run_two" || touch "$instant_run_two"

--- a/compatibility.txt
+++ b/compatibility.txt
@@ -20,7 +20,7 @@ if [ "$ps_accounts" -gt "1" ]; then
 	chmod 0777 "$instant_run_two"
 	echo -e "PLAY_DB_DIR=/data/data/com.android.vending/databases\nSQLITE=${MAGMOD}\n\n\nam force-stop com.android.vending\n\ncd \$SQLITE\nsleep 1\n" >> "$instant_run_two"
 	am force-stop com.android.vending
-	for i in {1..${ps_accounts_final}}; do sed -n '/^\s*$SQLITE\/sqlite.*/p' "$instant_run" >> "$instant_run_two"; done
+	for i in {1..${ps_accounts_final}}; do sed -n '/^[[:space:]]*$SQLITE\/sqlite.*/p' "$instant_run" >> "$instant_run_two"; done
 	#sed -i -e "s/.$(echo a | tr 'a' '\t')\/sqlite/\$SQLITE\/sqlite/" "$instant_run_two"
 	#sed -i -e 's/..\/sqlite/$SQLITE\/sqlite/' "$instant_run_two"
 	#sed -i -e 's/.\/sqlite/$SQLITE\/sqlite/' "$instant_run_two"

--- a/compatibility.txt
+++ b/compatibility.txt
@@ -1,7 +1,9 @@
-MAGMOD=/data/adb/modules/Detach
+#MODDIR=${0%/*}
+#MAGMOD=$MODDIR
 instant_run=$MAGMOD/instant_run.sh
 instant_run_two=$MAGMOD/instant_run_two.sh
-MAGMOD=$MODDIR
+#SQLITE=$MAGMOD
+
 
 # Multiple Play Store accounts compatibility
 ps_accounts=$("$MODDIR/sqlite" $PS_DATA_PATH "SELECT account FROM ownership" | sort -u | wc -l)
@@ -16,15 +18,15 @@ chmod 0777 "$MAGMOD/first_detach_result.txt"
 if [ "$ps_accounts" -gt "1" ]; then
 	test -e "$instant_run_two" || touch "$instant_run_two"
 	chmod 0777 "$instant_run_two"
-	echo -e "PLAY_DB_DIR=/data/data/com.android.vending/databases\nSQLITE=${MAGMOD}/Detach\n\n\nam force-stop com.android.vending\n\ncd \$SQLITE\n\n" > "$instant_run_two"
+	echo -e "PLAY_DB_DIR=/data/data/com.android.vending/databases\nSQLITE=${MAGMOD}\n\n\nam force-stop com.android.vending\n\ncd \$SQLITE\nSleep 1;\n" >> "$instant_run_two"
 	am force-stop com.android.vending
-	for i in {1..${ps_accounts_final}}; do grep sqlite "$instant_run" > "$instant_run_two"; done
-	sed -i -e 's/.\t\/sqlite/.\/sqlite/' "$instant_run_two"
-	sed -i -e 's/..\/sqlite/.\/sqlite/' "$instant_run_two"
-	sed -i -e "s/SQLITE=\$MODDIR\/sqlite//" "$instant_run_two"
+	for i in {1..${ps_accounts_final}}; do sed -n '/^\s*$SQLITE\/sqlite.*/p' "$instant_run" >> "$instant_run_two"; done
+	#sed -i -e "s/.$(echo a | tr 'a' '\t')\/sqlite/\$SQLITE\/sqlite/" "$instant_run_two"
+	#sed -i -e 's/..\/sqlite/$SQLITE\/sqlite/' "$instant_run_two"
+	#sed -i -e 's/.\/sqlite/$SQLITE\/sqlite/' "$instant_run_two"
 	echo -e '\n' >> "$instant_run_two"
 	
-	sh "$instant_run_two" > "$MAGMOD/second_detach_result.txt" 2>&1
+	su -c sh "$instant_run_two" > "$MAGMOD/second_detach_result.txt" 2>&1
 fi
 
 	
@@ -41,7 +43,7 @@ if grep -q "$wrong_result" "$MAGMOD/first_detach_result.txt"; then
 	PLAY_DB_DIR=/data/data/com.android.vending/databases
 	
 	grep sqlite "$SERVICESH" > "$ACTAPPS"
-	sed -i -e "s/.\/sqlite \$PLAY_DB_DIR\/library.db \"UPDATE ownership SET library_id = 'u-wl' where doc_id = '//" -i -e "s/'\";//" "$ACTAPPS"
+	sed -i -e "s/\$SQLITE\/sqlite \$PLAY_DB_DIR\/library.db \"UPDATE ownership SET library_id = 'u-wl' where doc_id = '//" -i -e "s/'\";//" "$ACTAPPS"
 	sed -i -e '1d' "$ACTAPPS"
 	sed -i -e 's/[[:blank:]]*//' "$ACTAPPS"
 	
@@ -53,7 +55,7 @@ if grep -q "$wrong_result" "$MAGMOD/first_detach_result.txt"; then
 	
 	FIRST_PCK_NAME=$(head -n 1 "$ACTAPPS")
 	PRESENT_DIR=$(pwd)
-	SQL_ENTRY_TEST=$(cd $MODDIR && ./sqlite $PS_DATA_PATH "SELECT * FROM ownership WHERE doc_id = '${FIRST_PCK_NAME}' AND library_id='3'" | wc -l)
+	SQL_ENTRY_TEST=$(cd $MODDIR && $SQLITE/sqlite $PS_DATA_PATH "SELECT * FROM ownership WHERE doc_id = '${FIRST_PCK_NAME}' AND library_id='3'" | wc -l)
 	cd "$PRESENT_DIR"
 	ZERO=0
 	
@@ -62,19 +64,19 @@ if grep -q "$wrong_result" "$MAGMOD/first_detach_result.txt"; then
 	if [ "$SQL_ENTRY_TEST" -eq 1 ]; then
 		echo -e "\ncd $MAGMOD\n\n" >> "$FINAL"
 		printf '%s\n' "$var_ACTAPPS" | while IFS= read -r line
-			do echo -e "./sqlite $PLAY_DB_DIR/library.db \"DELETE FROM ownership WHERE doc_id = '$line' AND library_id = '3'\";\n" >> "$FINAL"
+			do echo -e "$SQLITE/sqlite $PLAY_DB_DIR/library.db \"DELETE FROM ownership WHERE doc_id = '$line' AND library_id = '3'\";\n" >> "$FINAL"
 		done
 		chmod +x "$FINAL"
-		sh "$FINAL"
+		su -c sh "$FINAL"
 	else
 		echo -e "\ncd $MAGMOD\n\n" >> "$FINAL"
 		while [ "$ZERO" -le "$SQL_ENTRY_TEST" ]; do
 			printf '%s\n' "$var_ACTAPPS" | while IFS= read -r line
-				do echo -e "./sqlite $PLAY_DB_DIR/library.db \"DELETE FROM ownership WHERE doc_id = '$line' AND library_id = '3'\";\n" >> "$FINAL"
+				do echo -e "$SQLITE/sqlite $PLAY_DB_DIR/library.db \"DELETE FROM ownership WHERE doc_id = '$line' AND library_id = '3'\";\n" >> "$FINAL"
 			done
 			SQL_ENTRY_TEST=$(($SQL_ENTRY_TEST - 1))
 		done
-		sh "$FINAL"
+		su -c sh "$FINAL"
 	fi
 	
 	for f in "$ACTAPPS" "$ACTAPPSBCK" "$MAGMOD/first_detach_result.txt"; do rm -f "$f"; done
@@ -83,3 +85,6 @@ else
 	echo -e "\nDone\n"
 	[ -e "$MODDIR/silent" ] || echo -e "Instant file ready to be executed, path of the file:\n $instant_run\n"
 fi
+
+#For while loop closing in main.sh
+done &)

--- a/customize.sh
+++ b/customize.sh
@@ -21,7 +21,7 @@ pre_request() {
 ui_print
 ui_print "- Extracting module files"
 [ ! -d "$MODPATH/system/bin" ] && mkdir -p "$MODPATH/system/bin"
-unzip -o "$ZIPFILE" module.prop service.sh compatibility.txt sqlite sqlite.txt 'system/*' -x LICENSE .gitattributes README.md -d "$TMPDIR" 1>/dev/null
+unzip -o "$ZIPFILE" module.prop service.sh main.sh compatibility.txt sqlite sqlite.txt 'system/*' -x LICENSE .gitattributes README.md -d "$TMPDIR" 1>/dev/null
 
 [ ! -e "$TMPDIR/system/bin/Detach" ] && unzip -o "$ZIPFILE" 'system/system/bin/Detach' "$TMPDIR/system/bin/Detach"
 
@@ -65,7 +65,7 @@ sleep 1;
 ui_print "- Prepare stuff"
 
 
-SERVICESH=$TMPDIR/service.sh
+SERVICESH=$TMPDIR/main.sh
 CONF=$(ls /sdcard/Detach.txt || ls /sdcard/detach.txt || ls /sdcard/DETACH.txt || ls /storage/emulated/0/detach.txt || ls /storage/emulated/0/Detach.txt || ls /storage/emulated/0/DETACH.txt) 2>/dev/null;
 
 if [ "$CONF" != "/sdcard/Detach.txt" -o "$CONF" != "/storage/emulated/0/Detach.txt" ]; then
@@ -85,7 +85,7 @@ grep -q '\.' "$TMPDIR/SYN_CONF.txt"; if [ $? -eq 0 ]; then
 fi
 
 
-UP_SERVICESSH=$MODPATH/service.sh
+UP_SERVICESSH=$MODPATH/main.sh
 if [ -e "$UP_SERVICESSH" ] && test ! "$CONF_BAD"; then
 	CTSERVICESH=$(awk 'END{print NR}' $UP_SERVICESSH)
 	if [ "$CTSERVICESH" -gt "32" ]; then
@@ -214,6 +214,12 @@ if grep -qo '^YouTube' $CONF; then
 	ui_print "- YouTube"
 	echo '  # YouTube' >> $DETACH
 	echo '	./sqlite $PLAY_DB_DIR/library.db "UPDATE ownership SET library_id = '\'u-wl\' where doc_id = \'com.google.android.youtube\''";' >> $DETACH
+	echo '' >> $DETACH
+fi
+if grep -qo '^YouTube Music' $CONF; then
+	ui_print "- YouTube Music"
+	echo '  # YouTube Music' >> $DETACH
+	echo '	./sqlite $PLAY_DB_DIR/library.db "UPDATE ownership SET library_id = '\'u-wl\' where doc_id = \'com.google.android.apps.youtube.music\''";' >> $DETACH
 	echo '' >> $DETACH
 fi
 if grep -qo '^Gboard' $CONF; then
@@ -580,7 +586,7 @@ sleep 1;
 complete_script() {
 # =============================================
 ui_print "- Extracting module files"
-for i in "$TMPDIR/compatibility.txt" "$TMPDIR/sqlite" "$TMPDIR/sqlite.txt" "$TMPDIR/module.prop"; do cp -af "$i" "$MODPATH/"; done
+for i in "$TMPDIR/compatibility.txt" "$TMPDIR/sqlite" "$TMPDIR/service.sh" "$TMPDIR/sqlite.txt" "$TMPDIR/module.prop"; do cp -af "$i" "$MODPATH/"; done
 
 
 # =============================================
@@ -590,6 +596,8 @@ set_perm_recursive $TMPDIR 0 0 0755 0644
 set_perm $MODPATH/system/bin/Detach 0 0 0777
 chmod 0755 $TMPDIR/sqlite
 chgrp 2000 $TMPDIR/sqlite
+
+chmod 0755 "$MODPATH/service.sh" && chmod +x "$MODPATH/service.sh"
 
 chmod 0755 $MODPATH/sqlite
 chgrp 2000 $MODPATH/sqlite
@@ -601,11 +609,11 @@ cat "$TMPDIR/compatibility.txt" >> "$SERVICESH"
 
 echo "" >> "$SERVICESH"
 echo "# Exit" >> "$SERVICESH"
-echo "	exit; fi" >> "$SERVICESH"
+#echo " fi" >> "$SERVICESH"
 echo "done &)" >> "$SERVICESH"
-
-cp -af "$SERVICESH" "$MODPATH/service.sh"
-
+#echo "}" >> "$SERVICESH"
+cp -af "$SERVICESH" "$MODPATH/main.sh"
+chmod 0755 "$MODPATH/main.sh" && chmod +x "$MODPATH/main.sh"
 
 ui_print "- Boot script file is now finished."
 ui_print "- Reboot your device before using the terminal commands."

--- a/customize.sh
+++ b/customize.sh
@@ -497,7 +497,7 @@ ps_accounts=$("$TMPDIR/sqlite" $PS_DATA_PATH "SELECT account FROM ownership" | s
 cat /dev/null > "$instant_run"
 
 echo -e "PLAY_DB_DIR=/data/data/com.android.vending/databases\nSQLITE=${TMPDIR}\n\n\nam force-stop com.android.vending\n\ncd \$SQLITE\nsleep 1\n" >> "$instant_run"
-sed -n '32,$p' "$SERVICESH" | sed -n '/^\s*$SQLITE\/sqlite.*/p' "$SERVICESH" >> "$instant_run"
+sed -n '32,$p' "$SERVICESH" | sed -n '/^[[:space:]]*$SQLITE\/sqlite.*/p' "$SERVICESH" >> "$instant_run"
 	
 echo -e "\n" >> "$instant_run"
 	
@@ -510,7 +510,7 @@ if [ "$ps_accounts" -gt "1" ]; then
 	chmod 0777 "$instant_run_two" && chmod +x "$instant_run_two"
 	echo -e "PLAY_DB_DIR=/data/data/com.android.vending/databases\nSQLITE=${TMPDIR}\n\n\nam force-stop com.android.vending\n\ncd \$SQLITE\nsleep 1\n" > "$instant_run_two"
 	am force-stop com.android.vending
-	for i in {1..${ps_accounts_final}}; do sed -n '/^\s*$SQLITE\/sqlite.*/p' "$instant_run" >> "$instant_run_two"; done
+	for i in {1..${ps_accounts_final}}; do sed -n '/^[[:space:]]*$SQLITE\/sqlite.*/p' "$instant_run" >> "$instant_run_two"; done
 	#sed -i -e "s/.$(echo a | tr 'a' '\t')\/sqlite/\$SQLITE\/sqlite/" "$instant_run_two"
 	#sed -i -e 's/..\/sqlite/$SQLITE\/sqlite/' "$instant_run_two"
 	#sed -i -e 's/.\/sqlite/$SQLITE\/sqlite/' "$instant_run_two"
@@ -535,7 +535,7 @@ if grep -q "$wrong_result" "$TMPDIR/first_detach_result.txt"; then
 	for o in "$ACTAPPS" "$ACTAPPSBCK" "$FINAL"; do touch "$o" && cat /dev/null > "$o" && chmod 0644 "$o"; done
 	
 	PLAY_DB_DIR=/data/data/com.android.vending/databases
-	sed -n '/^\s*$SQLITE\/sqlite.*/p' "$SERVICESH" >> "$ACTAPPS"
+	sed -n '/^[[:space:]]*$SQLITE\/sqlite.*/p' "$SERVICESH" >> "$ACTAPPS"
 	#grep sqlite "$SERVICESH" > "$ACTAPPS"
 	sed -i -e "s/\$SQLITE\/sqlite \$PLAY_DB_DIR\/library.db \"UPDATE ownership SET library_id = 'u-wl' where doc_id = '//" -i -e "s/'\";//" "$ACTAPPS"
 	sed -i -e '1d' "$ACTAPPS"

--- a/customize.sh
+++ b/customize.sh
@@ -496,7 +496,7 @@ ps_accounts=$("$TMPDIR/sqlite" $PS_DATA_PATH "SELECT account FROM ownership" | s
 	
 cat /dev/null > "$instant_run"
 
-echo -e "PLAY_DB_DIR=/data/data/com.android.vending/databases\nSQLITE=${TMPDIR}\n\n\nam force-stop com.android.vending\n\ncd \$SQLITE\nSleep 1;\n" >> "$instant_run"
+echo -e "PLAY_DB_DIR=/data/data/com.android.vending/databases\nSQLITE=${TMPDIR}\n\n\nam force-stop com.android.vending\n\ncd \$SQLITE\nsleep 1\n" >> "$instant_run"
 sed -n '32,$p' "$SERVICESH" | sed -n '/^\s*$SQLITE\/sqlite.*/p' "$SERVICESH" >> "$instant_run"
 	
 echo -e "\n" >> "$instant_run"
@@ -508,7 +508,7 @@ sh "$instant_run" > "$TMPDIR/first_detach_result.txt" 2>&1
 if [ "$ps_accounts" -gt "1" ]; then
 	test -e "$instant_run_two" || touch "$instant_run_two"
 	chmod 0777 "$instant_run_two" && chmod +x "$instant_run_two"
-	echo -e "PLAY_DB_DIR=/data/data/com.android.vending/databases\nSQLITE=${TMPDIR}\n\n\nam force-stop com.android.vending\n\ncd \$SQLITE\nSleep 1;\n" > "$instant_run_two"
+	echo -e "PLAY_DB_DIR=/data/data/com.android.vending/databases\nSQLITE=${TMPDIR}\n\n\nam force-stop com.android.vending\n\ncd \$SQLITE\nsleep 1\n" > "$instant_run_two"
 	am force-stop com.android.vending
 	for i in {1..${ps_accounts_final}}; do sed -n '/^\s*$SQLITE\/sqlite.*/p' "$instant_run" >> "$instant_run_two"; done
 	#sed -i -e "s/.$(echo a | tr 'a' '\t')\/sqlite/\$SQLITE\/sqlite/" "$instant_run_two"

--- a/customize.sh
+++ b/customize.sh
@@ -21,13 +21,20 @@ pre_request() {
 ui_print
 ui_print "- Extracting module files"
 [ ! -d "$MODPATH/system/bin" ] && mkdir -p "$MODPATH/system/bin"
-unzip -o "$ZIPFILE" module.prop service.sh main.sh compatibility.txt sqlite sqlite.txt 'system/*' -x LICENSE .gitattributes README.md -d "$TMPDIR" 1>/dev/null
+unzip -o "$ZIPFILE" module.prop service.sh main.sh appslist.csv compatibility.txt sqlite sqlite.txt 'system/*' -x LICENSE .gitattributes README.md -d "$TMPDIR" 1>/dev/null
 
 [ ! -e "$TMPDIR/system/bin/Detach" ] && unzip -o "$ZIPFILE" 'system/system/bin/Detach' "$TMPDIR/system/bin/Detach"
 
+#sed -i "8i\MODDIR=$baseDir" "$TMPDIR/system/bin/Detach"
+#sed -i "231i\MODDIR=$baseDir" "$TMPDIR/system/bin/Detach"
+#now copy it to it's location
 cp -af "$TMPDIR/system/bin/Detach" "$MODPATH/system/bin/Detach"
+#Write MODDIR=data/adb/modules/Detach
+baseDir=$(echo $MODPATH | sed s/"_update"//)
+sed  -i -e 's~^MODDIR.*$~MODDIR='"${baseDir}"'~g' "$MODPATH/system/bin/Detach"
 
 rm -f "$TMPDIR/LICENCE" && rm -f "$MODPATH/LICENCE"
+rm -f "$TMPDIR/Detach.txt" && rm -f "$MODPATH/Detach.txt"
 rm -f "$TMPDIR/.gitattributes" && rm -f "$MODPATH/.gitattributes"
 
 [ ! -e "$TMPDIR/sqlite" ] && abort 'sqlite no exist!'
@@ -50,8 +57,8 @@ ui_print " "
 ui_print "- Checking pre-requests"
 sleep 1;
 
-
 if [[ -e "$BBOX_PATH/disable" || -e "$BBOX_PATH/SKIP_MOUNT" || -e "$BBOX_PATH/update" ]]; then
+
 	ui_print "!- Make sure you have the 'Busybox for Android-NDK' installed on your device,"
 	ui_print "!- enabled and up-to-date in your Magisk Manager."
 	ui_print "!- It's a pre-request for the module."
@@ -67,6 +74,7 @@ ui_print "- Prepare stuff"
 
 SERVICESH=$TMPDIR/main.sh
 CONF=$(ls /sdcard/Detach.txt || ls /sdcard/detach.txt || ls /sdcard/DETACH.txt || ls /storage/emulated/0/detach.txt || ls /storage/emulated/0/Detach.txt || ls /storage/emulated/0/DETACH.txt) 2>/dev/null;
+SQLITE=$TMPDIR
 
 if [ "$CONF" != "/sdcard/Detach.txt" -o "$CONF" != "/storage/emulated/0/Detach.txt" ]; then
 mv -f "$CONF" /sdcard/Detach.txt
@@ -114,7 +122,7 @@ CONF_CHECK3=$(wc -l "$CONF" | sed "s| $CONF||")
 if [ ! "$CONF_CHECK1" -o ! "$CONF_CHECK2" -o "$CONF_CHECK3" -lt "40" -a "$BOOT_TWRP" = 0 ]; then
 	ui_print "!- Make sure you have the original 'Detach.txt' file"; sleep 1;
 	ui_print "=> Download the original 'Detach.txt' file"
-	am start -a android.intent.action.VIEW -d https://github.com/xerta555/Detach-Files/raw/master/Detach.txt
+	am start -a android.intent.action.VIEW -d https://raw.githubusercontent.com/sobuj53/Detach/master/Detach.txt
 	abort "!- Module setup canceled"
 fi
 }
@@ -189,224 +197,224 @@ echo "" >> "$DETACH"
 if grep -qo '^Gmail' $CONF; then
 	ui_print "- Gmail"
 	echo "  # Gmail" >> $DETACH
-	echo '	./sqlite $PLAY_DB_DIR/library.db "UPDATE ownership SET library_id = '\'u-wl\' where doc_id = \'com.google.android.gm\''";' >> $DETACH
+	echo '	$SQLITE/sqlite $PLAY_DB_DIR/library.db "UPDATE ownership SET library_id = '\'u-wl\' where doc_id = \'com.google.android.gm\''";' >> $DETACH
 	echo '' >> $DETACH
 fi
 if grep -qo '^Google App' $CONF; then
 	ui_print "- Google App"
 	echo '  # Google App' >> $DETACH
-	echo '	./sqlite $PLAY_DB_DIR/library.db "UPDATE ownership SET library_id = '\'u-wl\' where doc_id = \'com.google.android.googlequicksearchbox\''";' >> $DETACH
+	echo '	$SQLITE/sqlite $PLAY_DB_DIR/library.db "UPDATE ownership SET library_id = '\'u-wl\' where doc_id = \'com.google.android.googlequicksearchbox\''";' >> $DETACH
 	echo '' >> $DETACH
 fi
 if grep -qo '^Google Plus' $CONF; then
 	ui_print "- Google Plus"
 	echo '  # Google Plus' >> $DETACH
-	echo '	./sqlite $PLAY_DB_DIR/library.db "UPDATE ownership SET library_id = '\'u-wl\' where doc_id = \'com.google.android.apps.plus\''";' >> $DETACH
+	echo '	$SQLITE/sqlite $PLAY_DB_DIR/library.db "UPDATE ownership SET library_id = '\'u-wl\' where doc_id = \'com.google.android.apps.plus\''";' >> $DETACH
 	echo '' >> $DETACH
 fi
 if grep -qo '^Hangouts' $CONF; then
 	ui_print "- Hangouts"
 	echo '  # Hangouts' >> $DETACH
-	echo '	./sqlite $PLAY_DB_DIR/library.db "UPDATE ownership SET library_id = '\'u-wl\' where doc_id = \'com.google.android.talk\''";' >> $DETACH
+	echo '	$SQLITE/sqlite $PLAY_DB_DIR/library.db "UPDATE ownership SET library_id = '\'u-wl\' where doc_id = \'com.google.android.talk\''";' >> $DETACH
 	echo '' >> $DETACH
 fi
 if grep -qo '^YouTube' $CONF; then
 	ui_print "- YouTube"
 	echo '  # YouTube' >> $DETACH
-	echo '	./sqlite $PLAY_DB_DIR/library.db "UPDATE ownership SET library_id = '\'u-wl\' where doc_id = \'com.google.android.youtube\''";' >> $DETACH
+	echo '	$SQLITE/sqlite $PLAY_DB_DIR/library.db "UPDATE ownership SET library_id = '\'u-wl\' where doc_id = \'com.google.android.youtube\''";' >> $DETACH
 	echo '' >> $DETACH
 fi
 if grep -qo '^YouTube Music' $CONF; then
 	ui_print "- YouTube Music"
 	echo '  # YouTube Music' >> $DETACH
-	echo '	./sqlite $PLAY_DB_DIR/library.db "UPDATE ownership SET library_id = '\'u-wl\' where doc_id = \'com.google.android.apps.youtube.music\''";' >> $DETACH
+	echo '	$SQLITE/sqlite $PLAY_DB_DIR/library.db "UPDATE ownership SET library_id = '\'u-wl\' where doc_id = \'com.google.android.apps.youtube.music\''";' >> $DETACH
 	echo '' >> $DETACH
 fi
 if grep -qo '^Gboard' $CONF; then
 	ui_print "- Gboard"
 	echo '  # Gboard' >> $DETACH
-	echo '	./sqlite $PLAY_DB_DIR/library.db "UPDATE ownership SET library_id = '\'u-wl\' where doc_id = \'com.google.android.inputmethod.latin\''";' >> $DETACH
+	echo '	$SQLITE/sqlite $PLAY_DB_DIR/library.db "UPDATE ownership SET library_id = '\'u-wl\' where doc_id = \'com.google.android.inputmethod.latin\''";' >> $DETACH
 	echo '' >> $DETACH
 fi
 if grep -qo '^Contacts' $CONF; then
 	ui_print "- Contacts"
 	echo '  # Contacts' >> $DETACH
-	echo '	./sqlite $PLAY_DB_DIR/library.db "UPDATE ownership SET library_id = '\'u-wl\' where doc_id = \'com.google.android.contacts\''";' >> $DETACH
+	echo '	$SQLITE/sqlite $PLAY_DB_DIR/library.db "UPDATE ownership SET library_id = '\'u-wl\' where doc_id = \'com.google.android.contacts\''";' >> $DETACH
 	echo '' >> $DETACH
 	fi
 if grep -qo '^Phone' $CONF; then
 	ui_print "- Phone"
 	echo '  # Phone' >> $DETACH
-	echo '	./sqlite $PLAY_DB_DIR/library.db "UPDATE ownership SET library_id = '\'u-wl\' where doc_id = \'com.google.android.dialer\''";' >> $DETACH
+	echo '	$SQLITE/sqlite $PLAY_DB_DIR/library.db "UPDATE ownership SET library_id = '\'u-wl\' where doc_id = \'com.google.android.dialer\''";' >> $DETACH
 	echo '' >> $DETACH
 fi
 if grep -qo '^Photos' $CONF; then
 	ui_print "- Photos"
 	echo '  # Photos' >> $DETACH
-	echo '	./sqlite $PLAY_DB_DIR/library.db "UPDATE ownership SET library_id = '\'u-wl\' where doc_id = \'com.google.android.apps.photos\''";' >> $DETACH
+	echo '	$SQLITE/sqlite $PLAY_DB_DIR/library.db "UPDATE ownership SET library_id = '\'u-wl\' where doc_id = \'com.google.android.apps.photos\''";' >> $DETACH
 	echo '' >> $DETACH
 fi
 if grep -qo '^Clock' $CONF; then
 	ui_print "- Clock"
 	echo '  # Clock' >> $DETACH
-	echo '	./sqlite $PLAY_DB_DIR/library.db "UPDATE ownership SET library_id = '\'u-wl\' where doc_id = \'com.google.android.deskclock\''";' >> $DETACH
+	echo '	$SQLITE/sqlite $PLAY_DB_DIR/library.db "UPDATE ownership SET library_id = '\'u-wl\' where doc_id = \'com.google.android.deskclock\''";' >> $DETACH
 	echo '' >> $DETACH
 fi
 if grep -qo '^Camera' $CONF; then
 	ui_print "- Camera"
 	echo '  # Camera' >> $DETACH
-	echo '	./sqlite $PLAY_DB_DIR/library.db "UPDATE ownership SET library_id = '\'u-wl\' where doc_id = \'com.google.android.GoogleCamera\''";' >> $DETACH
+	echo '	$SQLITE/sqlite $PLAY_DB_DIR/library.db "UPDATE ownership SET library_id = '\'u-wl\' where doc_id = \'com.google.android.GoogleCamera\''";' >> $DETACH
 	echo '' >> $DETACH
 fi
 if grep -qo '^Inbox' $CONF; then
 	ui_print "- Inbox"
 	echo '  # Inbox' >> $DETACH
-	echo '	./sqlite $PLAY_DB_DIR/library.db "UPDATE ownership SET library_id = '\'u-wl\' where doc_id = \'com.google.android.apps.inbox\''";' >> $DETACH
+	echo '	$SQLITE/sqlite $PLAY_DB_DIR/library.db "UPDATE ownership SET library_id = '\'u-wl\' where doc_id = \'com.google.android.apps.inbox\''";' >> $DETACH
 	echo '' >> $DETACH
 fi
 if grep -qo '^Duo' $CONF; then
 	ui_print "- Duo"
 	echo '  # Duo' >> $DETACH
-	echo '	./sqlite $PLAY_DB_DIR/library.db "UPDATE ownership SET library_id = '\'u-wl\' where doc_id = \'com.google.android.apps.tachyon\''";' >> $DETACH
+	echo '	$SQLITE/sqlite $PLAY_DB_DIR/library.db "UPDATE ownership SET library_id = '\'u-wl\' where doc_id = \'com.google.android.apps.tachyon\''";' >> $DETACH
 	echo '' >> $DETACH
 fi
 if grep -qo '^Dropbox' $CONF; then
 	ui_print "- Dropbox"
 	echo '  # Dropbox' >> $DETACH
-	echo '	./sqlite $PLAY_DB_DIR/library.db "UPDATE ownership SET library_id = '\'u-wl\' where doc_id = \'com.dropbox.android\''";' >> $DETACH
+	echo '	$SQLITE/sqlite $PLAY_DB_DIR/library.db "UPDATE ownership SET library_id = '\'u-wl\' where doc_id = \'com.dropbox.android\''";' >> $DETACH
 	echo '' >> $DETACH
 fi
 if grep -qo '^PushBullet' $CONF; then
 	ui_print "- PushBullet"
 	echo '  # PushBullet' >> $DETACH 
-	echo '	./sqlite $PLAY_DB_DIR/library.db "UPDATE ownership SET library_id = '\'u-wl\' where doc_id = \'com.pushbullet.android\''";' >> $DETACH
+	echo '	$SQLITE/sqlite $PLAY_DB_DIR/library.db "UPDATE ownership SET library_id = '\'u-wl\' where doc_id = \'com.pushbullet.android\''";' >> $DETACH
 	echo '' >> $DETACH
 fi
 if grep -qo '^Calendar' $CONF; then
 	ui_print "- Calendar"
 	echo '  # Calendar' >> $DETACH 
-	echo '	./sqlite $PLAY_DB_DIR/library.db "UPDATE ownership SET library_id = '\'u-wl\' where doc_id = \'com.google.android.calendar\''";' >> $DETACH
+	echo '	$SQLITE/sqlite $PLAY_DB_DIR/library.db "UPDATE ownership SET library_id = '\'u-wl\' where doc_id = \'com.google.android.calendar\''";' >> $DETACH
 	echo '' >> $DETACH
 fi
 if grep -qo '^Keep' $CONF; then
 	ui_print "- Keep"
 	echo '  # Keep' >> $DETACH 
-	echo '	./sqlite $PLAY_DB_DIR/library.db "UPDATE ownership SET library_id = '\'u-wl\' where doc_id = \'com.google.android.keep\''";' >> $DETACH
+	echo '	$SQLITE/sqlite $PLAY_DB_DIR/library.db "UPDATE ownership SET library_id = '\'u-wl\' where doc_id = \'com.google.android.keep\''";' >> $DETACH
 	echo '' >> $DETACH
 fi
 if grep -qo '^Telegram' $CONF; then
 	ui_print "- Telegram"
 	echo '  # Telegram' >> $DETACH 
-	echo '	./sqlite $PLAY_DB_DIR/library.db "UPDATE ownership SET library_id = '\'u-wl\' where doc_id = \'org.telegram.messenger\''";' >> $DETACH
+	echo '	$SQLITE/sqlite $PLAY_DB_DIR/library.db "UPDATE ownership SET library_id = '\'u-wl\' where doc_id = \'org.telegram.messenger\''";' >> $DETACH
 	echo '' >> $DETACH
 fi
 if grep -qo '^Swiftkey' $CONF; then
 	ui_print "- Swiftkey"
 	echo '  # Swiftkey' >> $DETACH 
-	echo '	./sqlite $PLAY_DB_DIR/library.db "UPDATE ownership SET library_id = '\'u-wl\' where doc_id = \'com.touchtype.swiftkey\''";' >> $DETACH
+	echo '	$SQLITE/sqlite $PLAY_DB_DIR/library.db "UPDATE ownership SET library_id = '\'u-wl\' where doc_id = \'com.touchtype.swiftkey\''";' >> $DETACH
 	echo '' >> $DETACH
 fi
 if grep -qo '^Translate' $CONF; then
 	ui_print "- Translate"
 	echo '  # Translate' >> $DETACH 
-	echo '	./sqlite $PLAY_DB_DIR/library.db "UPDATE ownership SET library_id = '\'u-wl\' where doc_id = \'com.google.android.apps.translate\''";' >> $DETACH
+	echo '	$SQLITE/sqlite $PLAY_DB_DIR/library.db "UPDATE ownership SET library_id = '\'u-wl\' where doc_id = \'com.google.android.apps.translate\''";' >> $DETACH
 	echo '' >> $DETACH
 fi
 if grep -qo '^Facebook' $CONF; then
 	ui_print "- Facebook"
 	echo '  # Facebook' >> $DETACH 
-	echo '	./sqlite $PLAY_DB_DIR/library.db "UPDATE ownership SET library_id = '\'u-wl\' where doc_id = \'com.facebook.katana\''";' >> $DETACH
+	echo '	$SQLITE/sqlite $PLAY_DB_DIR/library.db "UPDATE ownership SET library_id = '\'u-wl\' where doc_id = \'com.facebook.katana\''";' >> $DETACH
 	echo '' >> $DETACH
 fi
 if grep -qo '^Pandora' $CONF; then
 	ui_print "- Pandora"
 	echo '  # Pandora' >> $DETACH 
-	echo '	./sqlite $PLAY_DB_DIR/library.db "UPDATE ownership SET library_id = '\'u-wl\' where doc_id = \'com.pandora.android\''";' >> $DETACH
+	echo '	$SQLITE/sqlite $PLAY_DB_DIR/library.db "UPDATE ownership SET library_id = '\'u-wl\' where doc_id = \'com.pandora.android\''";' >> $DETACH
 	echo '' >> $DETACH
 fi
 if grep -qo '^Twitter' $CONF; then
 	ui_print "- Twitter"
 	echo '  # Twitter' >> $DETACH 
-	echo '	./sqlite $PLAY_DB_DIR/library.db "UPDATE ownership SET library_id = '\'u-wl\' where doc_id = \'com.twitter.android\''";' >> $DETACH
+	echo '	$SQLITE/sqlite $PLAY_DB_DIR/library.db "UPDATE ownership SET library_id = '\'u-wl\' where doc_id = \'com.twitter.android\''";' >> $DETACH
 	echo '' >> $DETACH
 fi
 if grep -qo '^Slack' $CONF; then
 	ui_print "- Slack"
 	echo '  # Slack' >> $DETACH 
-	echo '	./sqlite $PLAY_DB_DIR/library.db "UPDATE ownership SET library_id = '\'u-wl\' where doc_id = \'com.Slack\''";' >> $DETACH
+	echo '	$SQLITE/sqlite $PLAY_DB_DIR/library.db "UPDATE ownership SET library_id = '\'u-wl\' where doc_id = \'com.Slack\''";' >> $DETACH
 	echo '' >> $DETACH
 fi
 if grep -qo '^Mega' $CONF; then
 	ui_print "- Mega"
 	echo '  ' >> $DETACH 
 	echo '  # Mega' >> $DETACH 
-	echo '	./sqlite $PLAY_DB_DIR/library.db "UPDATE ownership SET library_id = '\'u-wl\' where doc_id = \'mega.privacy.android.app\''";' >> $DETACH
+	echo '	$SQLITE/sqlite $PLAY_DB_DIR/library.db "UPDATE ownership SET library_id = '\'u-wl\' where doc_id = \'mega.privacy.android.app\''";' >> $DETACH
 	echo '' >> $DETACH
 fi
 if grep -qo '^WhatsApp' $CONF; then
 	ui_print "- WhatsApp"
 	echo '  # WhatsApp' >> $DETACH 
-	echo '	./sqlite $PLAY_DB_DIR/library.db "UPDATE ownership SET library_id = '\'u-wl\' where doc_id = \'com.whatsapp\''";' >> $DETACH
+	echo '	$SQLITE/sqlite $PLAY_DB_DIR/library.db "UPDATE ownership SET library_id = '\'u-wl\' where doc_id = \'com.whatsapp\''";' >> $DETACH
 	echo '' >> $DETACH
 fi
 if grep -qo '^Voice' $CONF; then
 	ui_print "- Voice"
 	echo '  # Voice' >> $DETACH 
-	echo '	./sqlite $PLAY_DB_DIR/library.db "UPDATE ownership SET library_id = '\'u-wl\' where doc_id = \'com.google.android.apps.googlevoice\''";' >> $DETACH
+	echo '	$SQLITE/sqlite $PLAY_DB_DIR/library.db "UPDATE ownership SET library_id = '\'u-wl\' where doc_id = \'com.google.android.apps.googlevoice\''";' >> $DETACH
 	echo '' >> $DETACH
 fi
 if grep -qo '^Drive' $CONF; then
 	ui_print "- Drive"
 	echo '  # Drive' >> $DETACH 
-	echo '	./sqlite $PLAY_DB_DIR/library.db "UPDATE ownership SET library_id = '\'u-wl\' where doc_id = \'com.google.android.apps.docs\''";' >> $DETACH
+	echo '	$SQLITE/sqlite $PLAY_DB_DIR/library.db "UPDATE ownership SET library_id = '\'u-wl\' where doc_id = \'com.google.android.apps.docs\''";' >> $DETACH
 	echo '' >> $DETACH
 fi
 if grep -qo '^Netflix' $CONF; then
 	ui_print "- Netflix"
 	echo '  # Netflix' >> $DETACH 
-	echo '	./sqlite $PLAY_DB_DIR/library.db "UPDATE ownership SET library_id = '\'u-wl\' where doc_id = \'com.netflix.mediaclient\''";' >> $DETACH
+	echo '	$SQLITE/sqlite $PLAY_DB_DIR/library.db "UPDATE ownership SET library_id = '\'u-wl\' where doc_id = \'com.netflix.mediaclient\''";' >> $DETACH
 	echo '' >> $DETACH
 fi
 if grep -qo '^Pixel Launcher' $CONF; then
 	ui_print "- Pixel Launcher"
 	echo '  # Pixel Launcher' >> $DETACH 
-	echo '	./sqlite $PLAY_DB_DIR/library.db "UPDATE ownership SET library_id = '\'u-wl\' where doc_id = \'com.google.android.apps.nexuslauncher\''";' >> $DETACH
+	echo '	$SQLITE/sqlite $PLAY_DB_DIR/library.db "UPDATE ownership SET library_id = '\'u-wl\' where doc_id = \'com.google.android.apps.nexuslauncher\''";' >> $DETACH
 	echo '' >> $DETACH
 fi
 if grep -qo '^Wallpapers' $CONF; then
 	ui_print "- Wallpapers"
 	echo '  # Wallpapers' >> $DETACH 
-	echo '	./sqlite $PLAY_DB_DIR/library.db "UPDATE ownership SET library_id = '\'u-wl\' where doc_id = \'com.google.android.apps.wallpaper\''";' >> $DETACH
+	echo '	$SQLITE/sqlite $PLAY_DB_DIR/library.db "UPDATE ownership SET library_id = '\'u-wl\' where doc_id = \'com.google.android.apps.wallpaper\''";' >> $DETACH
 	echo '' >> $DETACH
 fi
 if grep -qo '^Capture' $CONF; then
 	ui_print "- Capture"
 	echo '  # Capture' >> $DETACH 
-	echo '	./sqlite $PLAY_DB_DIR/library.db "UPDATE ownership SET library_id = '\'u-wl\' where doc_id = \'com.gopro.smarty\''";' >> $DETACH
+	echo '	$SQLITE/sqlite $PLAY_DB_DIR/library.db "UPDATE ownership SET library_id = '\'u-wl\' where doc_id = \'com.gopro.smarty\''";' >> $DETACH
 	echo '' >> $DETACH
 fi
 if grep -qo '^Google Connectivity Services' $CONF; then
 	ui_print "- Google Connectivity Services"
 	echo '  # Google Connectivity Services' >> $DETACH 
-	echo '	./sqlite $PLAY_DB_DIR/library.db "UPDATE ownership SET library_id = '\'u-wl\' where doc_id = \'com.google.android.apps.gcs\''";' >> $DETACH
+	echo '	$SQLITE/sqlite $PLAY_DB_DIR/library.db "UPDATE ownership SET library_id = '\'u-wl\' where doc_id = \'com.google.android.apps.gcs\''";' >> $DETACH
 	echo '' >> $DETACH
 fi
 if grep -qo '^Google VR Services' $CONF; then
 	ui_print "- Google VR Services"
 	echo '  # Google VR Services' >> $DETACH 
-	echo '	./sqlite $PLAY_DB_DIR/library.db "UPDATE ownership SET library_id = '\'u-wl\' where doc_id = \'com.google.vr.vrcore\''";' >> $DETACH
+	echo '	$SQLITE/sqlite $PLAY_DB_DIR/library.db "UPDATE ownership SET library_id = '\'u-wl\' where doc_id = \'com.google.vr.vrcore\''";' >> $DETACH
 	echo '' >> $DETACH
 fi
 if grep -qo '^Google Play Services' $CONF; then
 	ui_print "- Google Play Services"
 	echo '  # Google Play Services' >> $DETACH 
-	echo '	./sqlite $PLAY_DB_DIR/library.db "UPDATE ownership SET library_id = '\'u-wl\' where doc_id = \'com.google.android.gms\''";' >> $DETACH
+	echo '	$SQLITE/sqlite $PLAY_DB_DIR/library.db "UPDATE ownership SET library_id = '\'u-wl\' where doc_id = \'com.google.android.gms\''";' >> $DETACH
 	echo '' >> $DETACH
 fi
 if grep -qo '^Google Carrier Services' $CONF; then 
 	ui_print "- Google Carrier Services"
 	echo '  # Google Carrier Services' >> $DETACH 
-	echo '	./sqlite $PLAY_DB_DIR/library.db "UPDATE ownership SET library_id = '\'u-wl\' where doc_id = \'com.google.android.ims\''";' >> $DETACH
+	echo '	$SQLITE/sqlite $PLAY_DB_DIR/library.db "UPDATE ownership SET library_id = '\'u-wl\' where doc_id = \'com.google.android.ims\''";' >> $DETACH
 fi
 cat "$DETACH" >> "$SERVICESH"
 
@@ -453,7 +461,7 @@ done
 
 printf '%s\n' "$FINAL_PACKS" | while IFS= read -r line
 	do
-		echo -e "	./sqlite \$PLAY_DB_DIR/library.db \"UPDATE ownership SET library_id = 'u-wl' where doc_id = '$line'\";\n" >> "$FINALCUST"
+		echo -e "	$SQLITE/sqlite \$PLAY_DB_DIR/library.db \"UPDATE ownership SET library_id = 'u-wl' where doc_id = '$line'\";\n" >> "$FINALCUST"
 done
 
 cat "$FINALCUST" >> "$SERVICESH"
@@ -488,8 +496,8 @@ ps_accounts=$("$TMPDIR/sqlite" $PS_DATA_PATH "SELECT account FROM ownership" | s
 	
 cat /dev/null > "$instant_run"
 
-echo -e "PLAY_DB_DIR=/data/data/com.android.vending/databases\nSQLITE=${TMPDIR}\n\n\nam force-stop com.android.vending\n\ncd \$SQLITE\n\n" >> "$instant_run"
-sed -n '32,$p' "$SERVICESH" | grep sqlite  >> "$instant_run"
+echo -e "PLAY_DB_DIR=/data/data/com.android.vending/databases\nSQLITE=${TMPDIR}\n\n\nam force-stop com.android.vending\n\ncd \$SQLITE\nSleep 1;\n" >> "$instant_run"
+sed -n '32,$p' "$SERVICESH" | sed -n '/^\s*$SQLITE\/sqlite.*/p' "$SERVICESH" >> "$instant_run"
 	
 echo -e "\n" >> "$instant_run"
 	
@@ -500,12 +508,13 @@ sh "$instant_run" > "$TMPDIR/first_detach_result.txt" 2>&1
 if [ "$ps_accounts" -gt "1" ]; then
 	test -e "$instant_run_two" || touch "$instant_run_two"
 	chmod 0777 "$instant_run_two" && chmod +x "$instant_run_two"
-	echo -e "PLAY_DB_DIR=/data/data/com.android.vending/databases\nSQLITE=$TMPDIR\n\n\nam force-stop com.android.vending\n\ncd \$SQLITE\n\n" > "$instant_run_two"
+	echo -e "PLAY_DB_DIR=/data/data/com.android.vending/databases\nSQLITE=${TMPDIR}\n\n\nam force-stop com.android.vending\n\ncd \$SQLITE\nSleep 1;\n" > "$instant_run_two"
 	am force-stop com.android.vending
-	for i in {1..${ps_accounts_final}}; do grep sqlite "$instant_run" >> "$instant_run_two"; done
-	sed -i -e 's/.\t\/sqlite/.\/sqlite/' "$instant_run_two"
-	sed -i -e 's/..\/sqlite/.\/sqlite/' "$instant_run_two"
-	sed -i -e "s/SQLITE=\$MODD.\/sqlite//" "$instant_run_two"
+	for i in {1..${ps_accounts_final}}; do sed -n '/^\s*$SQLITE\/sqlite.*/p' "$instant_run" >> "$instant_run_two"; done
+	#sed -i -e "s/.$(echo a | tr 'a' '\t')\/sqlite/\$SQLITE\/sqlite/" "$instant_run_two"
+	#sed -i -e 's/..\/sqlite/$SQLITE\/sqlite/' "$instant_run_two"
+	#sed -i -e 's/.\/sqlite/$SQLITE\/sqlite/' "$instant_run_two"
+	#sed -i -e "s/SQLITE=\$MODDIR.\/sqlite//" "$instant_run_two"
 	echo -e '\n' >> "$instant_run_two"
 	sh "$instant_run_two"
 	
@@ -526,9 +535,9 @@ if grep -q "$wrong_result" "$TMPDIR/first_detach_result.txt"; then
 	for o in "$ACTAPPS" "$ACTAPPSBCK" "$FINAL"; do touch "$o" && cat /dev/null > "$o" && chmod 0644 "$o"; done
 	
 	PLAY_DB_DIR=/data/data/com.android.vending/databases
-	
-	grep sqlite "$SERVICESH" > "$ACTAPPS"
-	sed -i -e "s/.\/sqlite \$PLAY_DB_DIR\/library.db \"UPDATE ownership SET library_id = 'u-wl' where doc_id = '//" -i -e "s/'\";//" "$ACTAPPS"
+	sed -n '/^\s*$SQLITE\/sqlite.*/p' "$SERVICESH" >> "$ACTAPPS"
+	#grep sqlite "$SERVICESH" > "$ACTAPPS"
+	sed -i -e "s/\$SQLITE\/sqlite \$PLAY_DB_DIR\/library.db \"UPDATE ownership SET library_id = 'u-wl' where doc_id = '//" -i -e "s/'\";//" "$ACTAPPS"
 	sed -i -e '1d' "$ACTAPPS"
 	sed -i -e 's/[[:blank:]]*//' "$ACTAPPS"
 		
@@ -540,7 +549,7 @@ if grep -q "$wrong_result" "$TMPDIR/first_detach_result.txt"; then
 	
 	FIRST_PCK_NAME=$(head -n 1 "$ACTAPPS")
 	PRESENT_DIR=$(pwd)
-	SQL_ENTRY_TEST=$(cd $TMPDIR && ./sqlite $PLAY_DB_DIR/library.db "SELECT * FROM ownership WHERE doc_id = '${FIRST_PCK_NAME}' AND library_id='3'" | wc -l)
+	SQL_ENTRY_TEST=$(cd $TMPDIR && $SQLITE/sqlite $PLAY_DB_DIR/library.db "SELECT * FROM ownership WHERE doc_id = '${FIRST_PCK_NAME}' AND library_id='3'" | wc -l)
 	cd "$PRESENT_DIR"
 	ZERO=0
 	chmod +x "$FINAL"
@@ -549,7 +558,7 @@ if grep -q "$wrong_result" "$TMPDIR/first_detach_result.txt"; then
 	
 	if [ "$SQL_ENTRY_TEST" -eq 1 ]; then
 		printf '%s\n' "$var_ACTAPPS" | while IFS= read -r line
-			do echo -e "./sqlite $PLAY_DB_DIR/library.db \"DELETE FROM ownership WHERE doc_id = '$line' AND library_id = '3'\";\n" >> "$FINAL"
+			do echo -e "$TMPDIR/sqlite $PLAY_DB_DIR/library.db \"DELETE FROM ownership WHERE doc_id = '$line' AND library_id = '3'\";\n" >> "$FINAL"
 		done
 		cd "$TMPDIR"
 		chmod +x "$FINAL"
@@ -559,7 +568,7 @@ if grep -q "$wrong_result" "$TMPDIR/first_detach_result.txt"; then
 		echo -e "\ncd $TMPDIR\n\n" >> "$FINAL"
 		while [ "$ZERO" -le "$SQL_ENTRY_TEST" ]; do
 			printf '%s\n' "$var_ACTAPPS" | while IFS= read -r line
-				do echo -e "./sqlite $PLAY_DB_DIR/library.db \"DELETE FROM ownership WHERE doc_id = '$line' AND library_id = '3'\";\n" >> "$FINAL"
+				do echo -e "$TMPDIR/sqlite $PLAY_DB_DIR/library.db \"DELETE FROM ownership WHERE doc_id = '$line' AND library_id = '3'\";\n" >> "$FINAL"
 			done
 			SQL_ENTRY_TEST=$(($SQL_ENTRY_TEST - 1))
 		done
@@ -586,7 +595,7 @@ sleep 1;
 complete_script() {
 # =============================================
 ui_print "- Extracting module files"
-for i in "$TMPDIR/compatibility.txt" "$TMPDIR/sqlite" "$TMPDIR/service.sh" "$TMPDIR/sqlite.txt" "$TMPDIR/module.prop"; do cp -af "$i" "$MODPATH/"; done
+for i in "$TMPDIR/compatibility.txt" "$TMPDIR/sqlite" "$TMPDIR/service.sh" "$TMPDIR/appslist.csv" "$TMPDIR/sqlite.txt" "$TMPDIR/module.prop"; do cp -af "$i" "$MODPATH/"; done
 
 
 # =============================================
@@ -607,10 +616,10 @@ ui_print "- Finish the script file..";sleep 1;
 
 cat "$TMPDIR/compatibility.txt" >> "$SERVICESH"
 
-echo "" >> "$SERVICESH"
-echo "# Exit" >> "$SERVICESH"
+#echo "" >> "$SERVICESH"
+#echo "# Exit" >> "$SERVICESH"
 #echo " fi" >> "$SERVICESH"
-echo "done &)" >> "$SERVICESH"
+#echo "done &)" >> "$SERVICESH"
 #echo "}" >> "$SERVICESH"
 cp -af "$SERVICESH" "$MODPATH/main.sh"
 chmod 0755 "$MODPATH/main.sh" && chmod +x "$MODPATH/main.sh"
@@ -677,7 +686,7 @@ if [ -e "$SIMPLE" -a "$CHECK_OTHER" -a ! "$CHECK_PACKAGES" ]; then
 	ui_print "!- Warning:"
 	ui_print "!- You have enable custom packages application"
 	ui_print "!- in your /sdcard/Detach.txt file".
-	ui_print "!- But you don't have write any custom packages names after that."
+	ui_print "!- But you didn't write any custom packages name after that."
 	ui_print "!- We are going to ignore it for this time."
 fi
 

--- a/main.sh
+++ b/main.sh
@@ -2,14 +2,14 @@
 # Do NOT assume where your module will be located.
 # ALWAYS use $MODDIR if you need to know where this script and module is placed.
 # This will make sure your module will still work if Magisk change its mount point in the future
-
 MODDIR=${0%/*}
 # This script will be executed in late_start service mode. More info in the main Magisk thread
 # Detach Apps from Market by hinxnz
 # Playstore database and SQLite directory'
 PLAY_DB_DIR=/data/data/com.android.vending/databases
-SQLITE=$MODDIR/sqlite
-
+MAGMOD=$MODDIR
+SQLITE=$MAGMOD
+SERVICESH=$MODDIR/main.sh
 # Wait till boot has completed'
 
 i=0
@@ -25,7 +25,7 @@ i=0
 # (in investigation..)	
 # Stop playstore to make changes
 	am force-stop com.android.vending
-
+	Sleep 1;
 # Change directory'
-	cd $MODDIR
+	cd $MAGMOD
 # Detach following apps from market

--- a/main.sh
+++ b/main.sh
@@ -25,7 +25,7 @@ i=0
 # (in investigation..)	
 # Stop playstore to make changes
 	am force-stop com.android.vending
-	Sleep 1;
+	sleep 1
 # Change directory'
 	cd $MAGMOD
 # Detach following apps from market

--- a/main.sh
+++ b/main.sh
@@ -6,29 +6,26 @@
 MODDIR=${0%/*}
 # This script will be executed in late_start service mode. More info in the main Magisk thread
 # Detach Apps from Market by hinxnz
+# Playstore database and SQLite directory'
+PLAY_DB_DIR=/data/data/com.android.vending/databases
+SQLITE=$MODDIR/sqlite
 
-MAGMOD=/data/adb/modules/Detach
+# Wait till boot has completed'
 
-#Let boot status 
 i=0
 # Wait till boot has completed'
 (while [ 1 ]; do
 
-	
-	sleep 5
+	((i++))
+	if [[ $i -gt 1 ]]; then break; fi
+#set boot status = ture
 
-	if [ `getprop sys.boot_completed` = 1 ]; then 
-	
-		((i++))
-		if [[ $i -gt 1 ]]; then
-			break
-		fi
-		#Reserved for crond schedule
-		
-		
-		#prevent recursive run
-		su -c sh "$MAGMOD/main.sh" > "$MAGMOD/first_detach_result.txt" 2>&1
-		
-	fi
-	
-done &)
+
+# Disable service that populates database
+# (in investigation..)	
+# Stop playstore to make changes
+	am force-stop com.android.vending
+
+# Change directory'
+	cd $MODDIR
+# Detach following apps from market

--- a/module.prop
+++ b/module.prop
@@ -1,6 +1,6 @@
 id=Detach
 name=Detach
-version=v4.3 BETA 8
-versionCode=438
+version=v4.3 BETA 9
+versionCode=439
 author=hinxnz, Rom, Sobuj53
 description=Detach Market Links for Theme Ready Apps, originaly created by hinxnz, ported by Rom to works with Magisk.

--- a/service.sh
+++ b/service.sh
@@ -21,7 +21,7 @@ MAGMOD=/data/adb/modules/Detach
 	
 	
 		#Reserved for crond schedule
-		crond -b -c /data/adb/modules/Detach/crons -L /storage/emulated/0/cronlogs.txt
+		
 		
 		
 		#prevent recursive run

--- a/service.sh
+++ b/service.sh
@@ -4,26 +4,24 @@
 # This will make sure your module will still work if Magisk change its mount point in the future
 
 MODDIR=${0%/*}
+
 # This script will be executed in late_start service mode. More info in the main Magisk thread
 # Detach Apps from Market by hinxnz
+
 
 MAGMOD=/data/adb/modules/Detach
 
 #Let boot status 
-i=0
-# Wait till boot has completed'
-(while [ 1 ]; do
 
-	
-	sleep 5
+# Wait till boot has completed'
+(while [ "$(getprop sys.boot_completed | tr -d '\r')" != "1" ]; do sleep 20; done
+
 
 	if [ `getprop sys.boot_completed` = 1 ]; then 
 	
-		((i++))
-		if [[ $i -gt 1 ]]; then
-			break
-		fi
+	
 		#Reserved for crond schedule
+		crond -b -c /data/adb/modules/Detach/crons -L /storage/emulated/0/cronlogs.txt
 		
 		
 		#prevent recursive run
@@ -31,4 +29,4 @@ i=0
 		
 	fi
 	
-done &)
+)

--- a/service.sh
+++ b/service.sh
@@ -2,14 +2,14 @@
 # Do NOT assume where your module will be located.
 # ALWAYS use $MODDIR if you need to know where this script and module is placed.
 # This will make sure your module will still work if Magisk change its mount point in the future
-
 MODDIR=${0%/*}
 
 # This script will be executed in late_start service mode. More info in the main Magisk thread
 # Detach Apps from Market by hinxnz
+#Modify the necessary varible MODDIR with magisk provided  varible eg. /data/adb/modules/Detach
+#sed  -i -e "s/^MODDIR.*$/MODDIR=${MODDIR}/" "$MODDIR/Detach"
 
-
-MAGMOD=/data/adb/modules/Detach
+MAGMOD=$MODDIR
 
 #Let boot status 
 

--- a/system/bin/Detach
+++ b/system/bin/Detach
@@ -22,12 +22,13 @@ N='\e[0m' > /dev/null 2>&1; # Null
 #Detach Directory
 MAGMOD=$MAGIMG/Detach
 #Boot service directory
-SERVICESH=$MAGMOD/service.sh
+SERVICESH=$MAGMOD/main.sh
 SILENT=$MAGMOD/silent
 
 #crond schedule file
 cronsfile=$MAGMOD/crons/root
 cronsDir=$MAGMOD/crons
+servicefile=$MAGMOD/service.sh
 
 #log file location
 if [ -d "/storage/emulated/0" ] 
@@ -126,7 +127,8 @@ if [ "$ps_accounts" -gt "1" ]; then
 	sh "$instant_run_two" > "$MAGMOD/second_detach_result.txt" 2>&1
 fi
 
-cp -f "$instant_run" /sdcard
+#stop coping to sdcard
+#cp -f "$instant_run" /sdcard
 	
 wrong_result=$(echo "Error: UNIQUE constraint failed: ownership.account,")
 if grep -q "$wrong_result" "$MAGMOD/first_detach_result.txt"; then
@@ -221,7 +223,7 @@ rm -f "$MAGMOD/apps_lists.txt"
 
 # Adding app
 add() {
-#SERVICESH=$MAGMOD/service.sh
+SERVICESH=$MAGMOD/main.sh
 CONF=$(ls /sdcard/Detach.txt || ls /storage/emulated/0/Detach.txt || ls /sdcard/detach.txt || ls /sdcard/DETACH.txt || ls /storage/emulated/0/detach.txt || ls /storage/emulated/0/DETACH.txt) 2>/dev/null;
 ACT_BASIC_APPS=$MAGMOD/act_basic_apps.txt
 ACT_CUST_APPS=$MAGMOD/act_cust_apps.txt
@@ -306,7 +308,8 @@ case $CONFIRMADD in
 		# Export sqlite cmds before writing all other contents in file (for Instant Run step)
 		su -c grep sqlite "$SERVICESH" | sed -i -e '1d' >> "$Instant_sqlite"
 		cat "$COMPATIBILITY" >> "$SERVICESH"
-		echo -e "\n\n# Exit\n	exit; fi\ndone &)\n" >> "$SERVICESH"
+		#echo -e "\n\n# Exit\n	exit; fi\ndone &)\n" >> "$SERVICESH"
+		echo -e "\n\n# Exit\ndone &)\n" >> "$SERVICESH"
 	else
 		# For custom
 		# Grep each sqlite commands with apps titles (common apps)
@@ -325,7 +328,8 @@ case $CONFIRMADD in
 		echo -e "\n\n" >> "$SERVICESH"
 		cat "$ACT_CUST_APPS" >> "$SERVICESH"
 		cat "$COMPATIBILITY" >> "$SERVICESH"
-		echo -e "\n\n# Exit\n	exit; fi\ndone &)\n" >> "$SERVICESH"
+		#echo -e "\n\n# Exit\n	exit; fi\ndone &)\n" >> "$SERVICESH"
+		echo -e "\n\n# Exit\ndone &)\n" >> "$SERVICESH"
 		echo -e $G"\n- Enable $WEB_NAME in your $CONF file.\n"$N
 		echo -e "$TOADD" >> "$CONF"
 	fi
@@ -410,13 +414,13 @@ case $CONFIRMADD in
 	*) echo $R"\n\nINVALID ENTRY, try again.\n"$N
 ;;
 esac
-
-cp -f "$instant_run" /sdcard
+#stop coping to sdcard
+#cp -f "$instant_run" /sdcard
 
 	
 rm -f "$ACT_BASIC_APPS"
 rm -f "$ACT_CUST_APPS"
-# rm -f "$instant_run"
+#rm -f "$instant_run"
 rm -f "$Instant_sqlite"
 rm -f "$MAGMOD/first_detach_result.txt"
 rm -f $MAGMOD/*.html
@@ -435,7 +439,7 @@ esac
 
 # Removing app
 rem() {
-#SERVICESH=$MAGMOD/service.sh
+SERVICESH=$MAGMOD/main.sh
 ACTAPPS=$MAGMOD/actapps.txt
 ACTAPPSRD=$MAGMOD/actapps_ready.txt
 SERVICESHFN=$MAGMOD/final_service.sh
@@ -646,6 +650,8 @@ case $SCHEDU in
 			echo -e $B"\nPlease select your desired crond schedule.\n1 for 30 minutes interval.\n2 for 1 hour interval.\n3 your choice.\nMake sure to check your input before entering (* * * *).\nFor help visit,\nhttps://crontab.guru\n\n4 to view current schedule (raw).\n5 to delete existing crond schedule.\n6 to exit.\n\nNow just make your choice..\n(1, 2, 3, 4,...)\n"$N
 			#echo -e $B"\nPlease enter your full crond command below.\nFormats for times: Minute (0-59) SPACE Hour (0-23) SPACE Day of mount (1-31) SPACE Month (1-12) SPACE Day of Week (0-6) (For Sunday=0 or 7)\nCommand exemple for every 2 hours:\ncrond 0 */2 * * * su -c detach -id\n\n"$N
 			read crond_entry
+			servicefile=$MAGMOD/service.sh
+			
 			case $crond_entry in
 				1|30|30M|30m|30min)
 				
@@ -683,7 +689,7 @@ case $SCHEDU in
 						if [ -f "$cronsfile" ]; then
 						
 							#remove schedule entry from service file
-							sed -i -e '/crond -b -c/d' "$SERVICESH"
+							sed -i -e '/crond -b -c/d' "$servicefile"
 							rm -rf "$cronsfile"
 							rm -rf "$LogFile"
 							
@@ -827,12 +833,13 @@ esac
 
 #function to write crond schedule in file
 WriteSchedule () {
-	
+
+	servicefile=$MAGMOD/service.sh
 	#remove schedule entry from service file
-	sed -i -e '/crond -b -c/d' "$SERVICESH"
+	sed -i -e '/crond -b -c/d' "$servicefile"
 	
 	test -e "$LogFile" &&  rm -rf "$LogFile"
-	test -e "$SERVICESH" || touch "$SERVICESH"
+	#test -e "$servicefile" || touch "$servicefile"
 	test -d "$cronsDir" || mkdir -p "$cronsDir"
 	chmod 0755 "$cronsDir"
 	
@@ -844,13 +851,13 @@ WriteSchedule () {
 				
 		Y|y|Yes|yes|YES)
 		#LogFile argument
-		sed -i "26i\crond -b -c $cronsDir -L $LogFile" "$SERVICESH"
+		sed -i "27i\		crond -b -c $cronsDir -L $LogFile" "$servicefile"
 		#echo "\ncrond -b -c $cronsDir -L $LogFile" >> "$SERVICESH"
 		echo -e "Log will be saved at\n$LogFile\n"
 	;;
 		N|n|No|no|NO)
 		#entry without log
-		sed -i "26i\crond -b -c $cronsDir" "$SERVICESH"
+		sed -i "27i\		crond -b -c $cronsDir" "$servicefile"
 		#echo "\ncrond -b -c $cronsDir" >> "$SERVICESH"
 	;;
 	esac
@@ -858,7 +865,7 @@ WriteSchedule () {
 	#echo "\ncrond -b -c $cronsDir -L $LogFile" >> "$SERVICESH"
 	
 	#Create a new one and run it
-	chmod 0755 "$SERVICESH" && chmod +x "$SERVICESH"
+	chmod 0755 "$servicefile" && chmod +x "$servicefile"
 			
 	#Create crons file if not available
 	test -e "$cronsfile" || touch "$cronsfile"
@@ -867,7 +874,7 @@ WriteSchedule () {
 	chmod 0755 "$cronsfile" && chmod +x "$cronsfile"
 			
 	#Execute
-	sh "$SERVICESH"
+	sh "$servicefile"
 	echo -e $Y"Rebooting once is recommended."$N
 
 }

--- a/system/bin/Detach
+++ b/system/bin/Detach
@@ -84,6 +84,9 @@ esac
 
 # Instant Detach
 ida() {
+MODDIR=/data/adb/modules/Detach
+#Detach Directory
+MAGMOD=$MODDIR
 Detach_version=$(grep 'version=.*' "$MAGMOD/module.prop" | sed 's/version=//')
 echo -e $C"\nDetach $Detach_version\n\nDetach work in progress..."$N
 
@@ -106,7 +109,7 @@ ps_accounts=$("$MAGMOD/sqlite" $PS_DATA_PATH "SELECT account FROM ownership" | s
 ps_accounts_final=$((ps_accounts+1))
 
 cat /dev/null > "$instant_run"
-echo -e "PLAY_DB_DIR=/data/data/com.android.vending/databases\nSQLITE=$MAGMOD\n\n\nam force-stop com.android.vending\n\ncd \$SQLITE\nSleep 1;\n" >> "$instant_run"
+echo -e "PLAY_DB_DIR=/data/data/com.android.vending/databases\nSQLITE=$MAGMOD\n\n\nam force-stop com.android.vending\n\ncd \$SQLITE\nsleep 1\n" >> "$instant_run"
 
 #egrep "^[[:space:]]*$SQLITE/sqlite" "$SERVICESH" >> "$instant_run"
 sed -n '/^\s*$SQLITE\/sqlite.*/p' "$SERVICESH" >> "$instant_run"
@@ -120,9 +123,9 @@ echo -e "\n" >> "$instant_run"
 if [ "$ps_accounts" -gt "1" ]; then
 	test -e "$instant_run_two" || touch "$instant_run_two"
 	chmod 0644 "$instant_run_two"
-	echo -e "PLAY_DB_DIR=/data/data/com.android.vending/databases\nSQLITE=$MAGMOD\n\n\nam force-stop com.android.vending\n\ncd \$SQLITE\nSleep 1;\n" > "$instant_run_two"
+	echo -e "PLAY_DB_DIR=/data/data/com.android.vending/databases\nSQLITE=$MAGMOD\n\n\nam force-stop com.android.vending\n\ncd \$SQLITE\nsleep 1\n" > "$instant_run_two"
 	am force-stop com.android.vending
-	sleep 1;
+	sleep 1
 	for i in {1..${ps_accounts_final}}; do sed -n '/^\s*$SQLITE\/sqlite.*/p' "$instant_run" >> "$instant_run_two"; done
 	#sed -i -e "s/.$(echo a | tr 'a' '\t')\/sqlite/\$SQLITE\/sqlite/" "$instant_run_two"
 	#sed -i -e 's/..\/sqlite/$SQLITE\/sqlite/' "$instant_run_two"
@@ -322,7 +325,7 @@ if ping -q -w1 -c1  8.8.8.8 > /dev/null; then
 			ps_accounts_final=$((ps_accounts+1))
 			
 			cat /dev/null > "$instant_run"
-			echo -e "PLAY_DB_DIR=/data/data/com.android.vending/databases\nSQLITE=${MAGMOD}\n\n\nam force-stop com.android.vending\n\ncd \$SQLITE\nSleep 1;\n" >> "$instant_run"
+			echo -e "PLAY_DB_DIR=/data/data/com.android.vending/databases\nSQLITE=${MAGMOD}\n\n\nam force-stop com.android.vending\n\ncd \$SQLITE\nsleep 1\n" >> "$instant_run"
 			
 			#not needed as passing whole path
 			sed -n '/^\s*$SQLITE\/sqlite.*/p' "$SERVICESH" >> "$instant_run"
@@ -337,9 +340,9 @@ if ping -q -w1 -c1  8.8.8.8 > /dev/null; then
 			if [ "$ps_accounts" -gt "1" ]; then
 				test -e "$instant_run_two" || touch "$instant_run_two"
 				chmod 0644 "$instant_run_two"
-				echo -e "PLAY_DB_DIR=/data/data/com.android.vending/databases\nSQLITE=${MAGMOD}\n\n\nam force-stop com.android.vending\n\ncd \$SQLITE\nSleep 1;\n" > "$instant_run_two"
+				echo -e "PLAY_DB_DIR=/data/data/com.android.vending/databases\nSQLITE=${MAGMOD}\n\n\nam force-stop com.android.vending\n\ncd \$SQLITE\nsleep 1\n" > "$instant_run_two"
 				am force-stop com.android.vending
-				sleep 1;
+				sleep 1
 				for i in {1..${ps_accounts_final}}; do sed -n '/^\s*$SQLITE\/sqlite.*/p' "$instant_run" >> "$instant_run_two"; done
 				#sed -i -e "s/.$(echo a | tr 'a' '\t')\/sqlite/$SQLITE\/sqlite/" "$instant_run_two"
 				#sed -i -e 's/..\/sqlite/$SQLITE\/sqlite/' "$instant_run_two"
@@ -363,7 +366,7 @@ if ping -q -w1 -c1  8.8.8.8 > /dev/null; then
 				sed -i -e 's/[[:blank:]]*//' "$ACTAPPS"
 				PLAY_DB_DIR=/data/data/com.android.vending/databases
 				cp -f "$ACTAPPS" "$ACTAPPSBCK"
-				echo -e "PLAY_DB_DIR=/data/data/com.android.vending/databases\nSQLITE=${MAGMOD}\n\n\nam force-stop com.android.vending\n\ncd \$SQLITE\nSleep 1;\n" >> "$FINAL"
+				echo -e "PLAY_DB_DIR=/data/data/com.android.vending/databases\nSQLITE=${MAGMOD}\n\n\nam force-stop com.android.vending\n\ncd \$SQLITE\nsleep 1\n" >> "$FINAL"
 				
 				var_ACTAPPS=$(awk '{ print }' "$ACTAPPSBCK")
 				for i in $(echo "$var_ACTAPPS"); do echo -e "$MAGMOD/sqlite $PLAY_DB_DIR/library.db \"DELETE FROM ownership WHERE doc_id = '$i' AND library_id = '3'\";" >> "$FINAL"; done
@@ -414,6 +417,9 @@ if ping -q -w1 -c1  8.8.8.8 > /dev/null; then
 
 # Removing app
 rem() {
+MODDIR=/data/adb/modules/Detach
+#Detach Directory
+MAGMOD=$MODDIR
 SERVICESH=$MAGMOD/main.sh
 ACTAPPS=$MAGMOD/actapps.txt
 ACTAPPSRD=$MAGMOD/actapps_ready.txt
@@ -428,13 +434,13 @@ chmod 0644 "$ACTAPPS"
 PS_DATA_PATH=/data/data/com.android.vending/databases/library.db
 
 #egrep "^[[:space:]]*$SQLITE/sqlite" "$SERVICESH" >> "$ACTAPPS"
-sed -n '/^\s*$SQLITE\/sqlite.*/p' "$SERVICESH" >> "$instant_run"
+sed -n '/^\s*$SQLITE\/sqlite.*/p' "$SERVICESH" >> "$ACTAPPS"
 sed -i -e "s/\$SQLITE\/sqlite \$PLAY_DB_DIR\/library.db \"UPDATE ownership SET library_id = 'u-wl' where doc_id = '//" -i -e "s/'\";//" "$ACTAPPS"
 sed -i -e 's/[ \t]*//' "$ACTAPPS"
 
 
 printf '%s\n' "$ACTAPPS" | while IFS= read -r line
-	do echo -e "\n\nHided app(s):\n$divider\n"
+	do echo -e "\n\nHidden app(s):\n$divider\n"
 	cat "$line"
 	echo -e "\n$divider\n"
 done
@@ -582,6 +588,10 @@ Now just make your choice..
 SCHEDULE
 
 read SCHEDU
+
+MODDIR=/data/adb/modules/Detach
+#Detach Directory
+MAGMOD=$MODDIR
 
 case $SCHEDU in
 	1|Tasker|tasker|TASKER)
@@ -809,6 +819,10 @@ esac
 
 #function to write crond schedule in file
 WriteSchedule () {
+
+MODDIR=/data/adb/modules/Detach
+#Detach Directory
+MAGMOD=$MODDIR
 
 	servicefile=$MAGMOD/service.sh
 	#remove schedule entry from service file

--- a/system/bin/Detach
+++ b/system/bin/Detach
@@ -87,6 +87,10 @@ ida() {
 MODDIR=/data/adb/modules/Detach
 #Detach Directory
 MAGMOD=$MODDIR
+#Boot service directory
+SERVICESH=$MAGMOD/main.sh
+CONF=$(ls /sdcard/detach.txt || ls /sdcard/Detach.txt || ls /sdcard/DETACH.txt || ls /storage/emulated/0/detach.txt || ls /storage/emulated/0/Detach.txt || ls /storage/emulated/0/DETACH.txt) 2>/dev/null;
+
 Detach_version=$(grep 'version=.*' "$MAGMOD/module.prop" | sed 's/version=//')
 echo -e $C"\nDetach $Detach_version\n\nDetach work in progress..."$N
 
@@ -112,7 +116,7 @@ cat /dev/null > "$instant_run"
 echo -e "PLAY_DB_DIR=/data/data/com.android.vending/databases\nSQLITE=$MAGMOD\n\n\nam force-stop com.android.vending\n\ncd \$SQLITE\nsleep 1\n" >> "$instant_run"
 
 #egrep "^[[:space:]]*$SQLITE/sqlite" "$SERVICESH" >> "$instant_run"
-sed -n '/^\s*$SQLITE\/sqlite.*/p' "$SERVICESH" >> "$instant_run"
+sed -n '/^[[:space:]]*$SQLITE\/sqlite.*/p' "$SERVICESH" >> "$instant_run"
 
 echo -e "\n" >> "$instant_run"
 
@@ -126,7 +130,7 @@ if [ "$ps_accounts" -gt "1" ]; then
 	echo -e "PLAY_DB_DIR=/data/data/com.android.vending/databases\nSQLITE=$MAGMOD\n\n\nam force-stop com.android.vending\n\ncd \$SQLITE\nsleep 1\n" > "$instant_run_two"
 	am force-stop com.android.vending
 	sleep 1
-	for i in {1..${ps_accounts_final}}; do sed -n '/^\s*$SQLITE\/sqlite.*/p' "$instant_run" >> "$instant_run_two"; done
+	for i in {1..${ps_accounts_final}}; do sed -n '/^[[:space:]]*$SQLITE\/sqlite.*/p' "$instant_run" >> "$instant_run_two"; done
 	#sed -i -e "s/.$(echo a | tr 'a' '\t')\/sqlite/\$SQLITE\/sqlite/" "$instant_run_two"
 	#sed -i -e 's/..\/sqlite/$SQLITE\/sqlite/' "$instant_run_two"
 	#sed -i -e 's/.\/sqlite/$SQLITE\/sqlite/' "$instant_run_two"
@@ -210,7 +214,7 @@ esac
 # List hided apps
 list() {
 apps_list_basic=$(tail -n +32 "$SERVICESH" | grep -e "# [A-Z]" | sed 's/# Custom Packages//' | sed 's/# Multiple.*//' | sed '$ d' | sed 's/[[:blank:]]*//' | grep "# [A-Za-z0-9]" | sed 's/# //')
-apps_list_cust=$(sed -n '/# Custom Packages/,$p' $SERVICESH | sed -n '/^\s*$SQLITE\/sqlite.*/p' |sed "s/\$SQLITE\/sqlite \$PLAY_DB_DIR\/library.db \"UPDATE ownership SET library_id = 'u-wl' where doc_id = '//" | sed "s/'\";//" | sed 's/[[:space:]]//')
+apps_list_cust=$(sed -n '/# Custom Packages/,$p' $SERVICESH | sed -n '/^[[:space:]]*$SQLITE\/sqlite.*/p' |sed "s/\$SQLITE\/sqlite \$PLAY_DB_DIR\/library.db \"UPDATE ownership SET library_id = 'u-wl' where doc_id = '//" | sed "s/'\";//" | sed 's/[[:space:]]//')
 
 echo "$apps_list_basic" >> "$MAGMOD/apps_lists.txt"
 echo "$apps_list_cust" >> "$MAGMOD/apps_lists.txt"
@@ -327,8 +331,9 @@ if ping -q -w1 -c1  8.8.8.8 > /dev/null; then
 			cat /dev/null > "$instant_run"
 			echo -e "PLAY_DB_DIR=/data/data/com.android.vending/databases\nSQLITE=${MAGMOD}\n\n\nam force-stop com.android.vending\n\ncd \$SQLITE\nsleep 1\n" >> "$instant_run"
 			
-			#not needed as passing whole path
-			sed -n '/^\s*$SQLITE\/sqlite.*/p' "$SERVICESH" >> "$instant_run"
+			#not needed as passing whole path 
+			#doen't work
+			sed -n '/^[[:space:]]*$SQLITE\/sqlite.*$/p' "$SERVICESH" >> "$ACTAPPS"
 			#egrep "^[[:space:]]*$SQLITE/sqlite" "$SERVICESH" >> "$instant_run"
 			
 			echo "" >> "$instant_run"
@@ -343,7 +348,7 @@ if ping -q -w1 -c1  8.8.8.8 > /dev/null; then
 				echo -e "PLAY_DB_DIR=/data/data/com.android.vending/databases\nSQLITE=${MAGMOD}\n\n\nam force-stop com.android.vending\n\ncd \$SQLITE\nsleep 1\n" > "$instant_run_two"
 				am force-stop com.android.vending
 				sleep 1
-				for i in {1..${ps_accounts_final}}; do sed -n '/^\s*$SQLITE\/sqlite.*/p' "$instant_run" >> "$instant_run_two"; done
+				for i in {1..${ps_accounts_final}}; do sed -n '/^[[:space:]]*$SQLITE\/sqlite.*/p' "$instant_run" >> "$instant_run_two"; done
 				#sed -i -e "s/.$(echo a | tr 'a' '\t')\/sqlite/$SQLITE\/sqlite/" "$instant_run_two"
 				#sed -i -e 's/..\/sqlite/$SQLITE\/sqlite/' "$instant_run_two"
 				#sed -i -e 's/.\/sqlite/$SQLITE\/sqlite/' "$instant_run_two"
@@ -434,7 +439,7 @@ chmod 0644 "$ACTAPPS"
 PS_DATA_PATH=/data/data/com.android.vending/databases/library.db
 
 #egrep "^[[:space:]]*$SQLITE/sqlite" "$SERVICESH" >> "$ACTAPPS"
-sed -n '/^\s*$SQLITE\/sqlite.*/p' "$SERVICESH" >> "$ACTAPPS"
+sed -n '/^[[:space:]]*$SQLITE\/sqlite.*/p' "$SERVICESH" >> "$ACTAPPS"
 sed -i -e "s/\$SQLITE\/sqlite \$PLAY_DB_DIR\/library.db \"UPDATE ownership SET library_id = 'u-wl' where doc_id = '//" -i -e "s/'\";//" "$ACTAPPS"
 sed -i -e 's/[ \t]*//' "$ACTAPPS"
 

--- a/system/bin/Detach
+++ b/system/bin/Detach
@@ -851,13 +851,13 @@ WriteSchedule () {
 				
 		Y|y|Yes|yes|YES)
 		#LogFile argument
-		sed -i "27i\		crond -b -c $cronsDir -L $LogFile" "$servicefile"
+		sed -i "24i\		crond -b -c $cronsDir -L $LogFile" "$servicefile"
 		#echo "\ncrond -b -c $cronsDir -L $LogFile" >> "$SERVICESH"
 		echo -e "Log will be saved at\n$LogFile\n"
 	;;
 		N|n|No|no|NO)
 		#entry without log
-		sed -i "27i\		crond -b -c $cronsDir" "$servicefile"
+		sed -i "24i\		crond -b -c $cronsDir" "$servicefile"
 		#echo "\ncrond -b -c $cronsDir" >> "$SERVICESH"
 	;;
 	esac

--- a/system/bin/Detach
+++ b/system/bin/Detach
@@ -4,9 +4,11 @@
 # Created by Rom@xda-developers
 
 menu() {
-# Initial stuff
-MAGIMG=/data/adb/modules
-
+# Initial stuff and this is reserved place for MODDIR
+MODDIR=/data/adb/modules/Detach
+#get previous directory, similar to MAGIMG=/data/adb/modules, 
+#this will be changed at installation run time
+MAGIMG="$(dirname "$MODDIR")"
 # Colors
 BL='\e[01;90m' > /dev/null 2>&1; # Black
 R='\e[01;91m' > /dev/null 2>&1; # Red
@@ -20,10 +22,11 @@ LG='\e[01;37m' > /dev/null 2>&1; # Light Gray
 N='\e[0m' > /dev/null 2>&1; # Null
 
 #Detach Directory
-MAGMOD=$MAGIMG/Detach
+MAGMOD=$MODDIR
 #Boot service directory
 SERVICESH=$MAGMOD/main.sh
 SILENT=$MAGMOD/silent
+SQLITE=$MAGMOD
 
 #crond schedule file
 cronsfile=$MAGMOD/crons/root
@@ -103,25 +106,27 @@ ps_accounts=$("$MAGMOD/sqlite" $PS_DATA_PATH "SELECT account FROM ownership" | s
 ps_accounts_final=$((ps_accounts+1))
 
 cat /dev/null > "$instant_run"
-echo -e "PLAY_DB_DIR=/data/data/com.android.vending/databases\nSQLITE=$MAGIMG/Detach\n\n\nam force-stop com.android.vending\n\ncd \$SQLITE\n\n" >> "$instant_run"
+echo -e "PLAY_DB_DIR=/data/data/com.android.vending/databases\nSQLITE=$MAGMOD\n\n\nam force-stop com.android.vending\n\ncd \$SQLITE\nSleep 1;\n" >> "$instant_run"
 
-egrep "^[[:space:]]*./sqlite" "$SERVICESH" >> "$instant_run"
+#egrep "^[[:space:]]*$SQLITE/sqlite" "$SERVICESH" >> "$instant_run"
+sed -n '/^\s*$SQLITE\/sqlite.*/p' "$SERVICESH" >> "$instant_run"
 
 echo -e "\n" >> "$instant_run"
 
 # test -e "$MAGMOD/first_detach_result.txt" || touch "$MAGMOD/first_detach_result.txt"
 # chmod 0644 "$MAGMOD/first_detach_result.txt"
-sh "$instant_run" > "$MAGMOD/first_detach_result.txt" 2>&1
+ sh "$instant_run" > "$MAGMOD/first_detach_result.txt" 2>&1
 
 if [ "$ps_accounts" -gt "1" ]; then
 	test -e "$instant_run_two" || touch "$instant_run_two"
 	chmod 0644 "$instant_run_two"
-	echo -e "PLAY_DB_DIR=/data/data/com.android.vending/databases\nSQLITE=$MAGIMG/Detach\n\n\nam force-stop com.android.vending\n\ncd \$SQLITE\n\n" > "$instant_run_two"
+	echo -e "PLAY_DB_DIR=/data/data/com.android.vending/databases\nSQLITE=$MAGMOD\n\n\nam force-stop com.android.vending\n\ncd \$SQLITE\nSleep 1;\n" > "$instant_run_two"
 	am force-stop com.android.vending
-	for i in {1..${ps_accounts_final}}; do grep sqlite "$instant_run" > "$instant_run_two"; done
-	sed -i -e 's/.\t\/sqlite/.\/sqlite/' "$instant_run_two"
-	sed -i -e 's/..\/sqlite/.\/sqlite/' "$instant_run_two"
-	sed -i -e "s/SQLITE=\$MODDIR.\/sqlite//" "$instant_run_two"
+	sleep 1;
+	for i in {1..${ps_accounts_final}}; do sed -n '/^\s*$SQLITE\/sqlite.*/p' "$instant_run" >> "$instant_run_two"; done
+	#sed -i -e "s/.$(echo a | tr 'a' '\t')\/sqlite/\$SQLITE\/sqlite/" "$instant_run_two"
+	#sed -i -e 's/..\/sqlite/$SQLITE\/sqlite/' "$instant_run_two"
+	#sed -i -e 's/.\/sqlite/$SQLITE\/sqlite/' "$instant_run_two"
 	echo -e '\n' >> "$instant_run_two"
 	
 	sh "$instant_run_two" > "$MAGMOD/second_detach_result.txt" 2>&1
@@ -142,8 +147,8 @@ if grep -q "$wrong_result" "$MAGMOD/first_detach_result.txt"; then
 	
 	PLAY_DB_DIR=/data/data/com.android.vending/databases
 	
-	awk '$1 == "./sqlite" { print; x++ } END { print x, "total matches" }' "$SERVICESH" | sed '$ d' >> "$ACTAPPS"
-	sed -i -e "s/.\/sqlite \$PLAY_DB_DIR\/library.db \"UPDATE ownership SET library_id = 'u-wl' where doc_id = '//" -i -e "s/'\";//" "$ACTAPPS"
+	awk '$1 == '$SQLITE/sqlite' { print; x++ } END { print x, "total matches" }' "$SERVICESH" | sed '$ d' >> "$ACTAPPS"
+	sed -i -e "s/\$SQLITE\/sqlite \$PLAY_DB_DIR\/library.db \"UPDATE ownership SET library_id = 'u-wl' where doc_id = '//" -i -e "s/'\";//" "$ACTAPPS"
 	# sed -i -e '1d' "$ACTAPPS"
 	sed -i -e 's/[[:blank:]]*//' "$ACTAPPS"
 		
@@ -154,7 +159,7 @@ if grep -q "$wrong_result" "$MAGMOD/first_detach_result.txt"; then
 	
 	FIRST_PCK_NAME=$(head -n 1 "$ACTAPPS")
 	PRESENT_DIR=$(pwd)
-	SQL_ENTRY_TEST=$(cd $MAGMOD && ./sqlite $PS_DATA_PATH "SELECT * FROM ownership WHERE doc_id = '${FIRST_PCK_NAME}' AND library_id='3'" | wc -l)
+	SQL_ENTRY_TEST=$(cd $MAGMOD && $SQLITE/sqlite $PS_DATA_PATH "SELECT * FROM ownership WHERE doc_id = '${FIRST_PCK_NAME}' AND library_id='3'" | wc -l)
 	cd "$PRESENT_DIR"
 	ZERO=0
 	
@@ -163,7 +168,7 @@ if grep -q "$wrong_result" "$MAGMOD/first_detach_result.txt"; then
 	if [ "$SQL_ENTRY_TEST" -eq 1 ]; then
 		echo -e "\ncd $MAGMOD\n\n" >> "$FINAL"
 		printf '%s\n' "$var_ACTAPPS" | while IFS= read -r line
-			do echo -e "./sqlite $PLAY_DB_DIR/library.db \"DELETE FROM ownership WHERE doc_id = '$line' AND library_id = '3'\";\n" >> "$FINAL"
+			do echo -e "$SQLITE/sqlite $PLAY_DB_DIR/library.db \"DELETE FROM ownership WHERE doc_id = '$line' AND library_id = '3'\";\n" >> "$FINAL"
 		done
 		chmod +x "$FINAL"
 		sh "$FINAL"
@@ -171,7 +176,7 @@ if grep -q "$wrong_result" "$MAGMOD/first_detach_result.txt"; then
 		echo -e "\ncd $MAGMOD\n\n" >> "$FINAL"
 		while [ "$ZERO" -le "$SQL_ENTRY_TEST" ]; do
 			printf '%s\n' "$var_ACTAPPS" | while IFS= read -r line
-				do echo -e "./sqlite $PLAY_DB_DIR/library.db \"DELETE FROM ownership WHERE doc_id = '$line' AND library_id = '3'\";\n" >> "$FINAL"
+				do echo -e "$SQLITE/sqlite $PLAY_DB_DIR/library.db \"DELETE FROM ownership WHERE doc_id = '$line' AND library_id = '3'\";\n" >> "$FINAL"
 			done
 			SQL_ENTRY_TEST=$(($SQL_ENTRY_TEST - 1))
 		done
@@ -202,11 +207,10 @@ esac
 # List hided apps
 list() {
 apps_list_basic=$(tail -n +32 "$SERVICESH" | grep -e "# [A-Z]" | sed 's/# Custom Packages//' | sed 's/# Multiple.*//' | sed '$ d' | sed 's/[[:blank:]]*//' | grep "# [A-Za-z0-9]" | sed 's/# //')
-apps_list_cust=$(sed -n '/# Custom Packages/,$p' $SERVICESH | egrep "^[[:space:]]*./sqlite" | sed "s/.\/sqlite \$PLAY_DB_DIR\/library.db \"UPDATE ownership SET library_id = 'u-wl' where doc_id = '//" | sed "s/'\";//" | sed 's/[[:space:]]//')
+apps_list_cust=$(sed -n '/# Custom Packages/,$p' $SERVICESH | sed -n '/^\s*$SQLITE\/sqlite.*/p' |sed "s/\$SQLITE\/sqlite \$PLAY_DB_DIR\/library.db \"UPDATE ownership SET library_id = 'u-wl' where doc_id = '//" | sed "s/'\";//" | sed 's/[[:space:]]//')
 
 echo "$apps_list_basic" >> "$MAGMOD/apps_lists.txt"
 echo "$apps_list_cust" >> "$MAGMOD/apps_lists.txt"
-
 
 FINAL_apps_list=$(awk '{ print }' "$MAGMOD/apps_lists.txt")
 
@@ -223,6 +227,10 @@ rm -f "$MAGMOD/apps_lists.txt"
 
 # Adding app
 add() {
+#Reserved place for MODDIR line 231
+MODDIR=data/adb/modules/Detach
+MAGMOD=$MODDIR
+servicefile=$MAGMOD/service.sh
 SERVICESH=$MAGMOD/main.sh
 CONF=$(ls /sdcard/Detach.txt || ls /storage/emulated/0/Detach.txt || ls /sdcard/detach.txt || ls /sdcard/DETACH.txt || ls /storage/emulated/0/detach.txt || ls /storage/emulated/0/DETACH.txt) 2>/dev/null;
 ACT_BASIC_APPS=$MAGMOD/act_basic_apps.txt
@@ -230,210 +238,177 @@ ACT_CUST_APPS=$MAGMOD/act_cust_apps.txt
 COMPATIBILITY=$MAGMOD/compatibility.txt
 Instant_sqlite=$MAGMOD/instant_sqlite.txt
 DL_CHECK=$MAGMOD/DL_check.txt
+backup_txt=$(date +'%m/%d/%Y')
+PS_DATA_PATH=/data/data/com.android.vending/databases/library.db
+applist=$MAGMOD/appslist.csv
 
-for i in "$ACT_BASIC_APPS" "$ACT_CUST_APPS" "$Instant_sqlite"; do  [ ! -e "$i" ] && touch "$i" && chmod -R 0644 "$i"; done
+#check net connecton
+if ping -q -w1 -c1  8.8.8.8 > /dev/null; then
 
-echo -e $C"\n\nPlease write the application package name\nyou want to detach from automatic PS update\n\nPackage name: "$N
-read TOADD
+		for i in "$ACT_BASIC_APPS" "$ACT_CUST_APPS" "$Instant_sqlite"; do  [ ! -e "$i" ] && touch "$i" && chmod -R 0644 "$i"; done
 
-echo -e $C"\n\n '$TOADD' - Do you confirm ?"$N; sleep 2;
-read CONFIRMADD
-if [ $(cat "$SERVICESH" | grep "$TOADD" | sed 's/  #//') ]; then
-	echo -e $R"\n! The name that you have entered already exist in your list\n=> Type su -c Detach -a or su and Detach -a again to add another package name in your list.\n\n"$N; sleep 3;
-	exit
-fi
+		echo -e $C"\n\nPlease write the application package name\nyou want to detach from automatic PS update.\n\n***Make suer to check your Detach.txt\n If the package is already there,\njust remove the # before that!\n\nPackage name: "$N
+		read TOADD
 
-if [ $(echo "$TOADD" | wc -l) -gt 1 ]; then
-	echo -e $R"\n! Please enter only one package name at a time."$N; sleep 3;
-	exit
-fi
+		echo -e $C"\n\n '$TOADD' - Do you confirm ? (yes or no)"$N; sleep 2;
+		read CONFIRMADD
+		if [ $(cat "$SERVICESH" | grep "$TOADD" | sed 's/  #//') ]; then
+			echo -e $R"\n! The name that you have entered already exist in your list\n=> Type su -c Detach -a or su and Detach -a again to add another package name in your list.\n\n"$N; sleep 3;
+			exit
+		fi
 
-case $CONFIRMADD in
-	Y|y|Yes|yes|YES)
-	echo -e $G"\nCheck if $TOADD exist on the Play Store..."$N; sleep 1;
-	# Check if user input exist on Play Store \(WIFI and/or LTE are require\)
-	touch "$DL_CHECK" && chmod 0777 "$DL_CHECK"
-	wget --no-check-certificate -T 5 -q -O "$MAGMOD/$TOADD.html" "https://play.google.com/store/apps/details?id=$TOADD&hl=en"
-	# Check for empty HTML page = 404 = Not Found = Custom apps don't exist on the Play Store
-	if [[ $(cat "$DL_CHECK" | grep '404' | awk '{ print $1 }' 2>/dev/null) -eq "404" ]] 2>/dev/null; then
-		echo 'a2'
-		echo -e "\nWarning: The package name of the application you just\nentered does not exist in the Play Store.\n"
-		rm -f "$ACT_BASIC_APPS"
-		rm -f "$ACT_CUST_APPS"
-		rm -f "$instant_run"
-		rm -f "$Instant_sqlite"
-		exit
-	fi
-	
-	
-	# Check if the app exist on the Play Store and if yes, get official app Name
-	wget --no-check-certificate -q -O "${MAGMOD}/$TOADD.html" "https://play.google.com/store/apps/details?id=${TOADD}&hl=en" --header "header: play.google.com" 2>&1 >> "$MAGMOD/$TOADD_DL_check.txt"
-	cat "$MAGMOD/$TOADD_DL_check.txt" | grep '404' | awk '{ print $1 }' > "$MAGMOD/$TOADD_DL_final_check.txt"
-	
-	if [ -s "$MAGMOD/$TOADD_DL_final_check.txt" ]; then
-		echo -e $R"\nApparently $TOADD don't exist on the Play Store or you don't have write the name correctly..."$N; sleep 2;
-		exit
-	else
-		grep 'AHFaub' "$MAGMOD/$TOADD.html" | tail -1 | cut -f1,2,3 -d'<' | sed 's/.*>//' | sed 's/(Trial)//' | sed 's/(Trial version)//' | sed 's/-.*//' | sed 's/:.*//' | sed 's/★.*//' | sed 's/ &amp.*//' | sed 's/\|.*//' | tr -d '\n' >> "$MAGMOD/$TOADD.txt"
-	fi
-	
-	
-	# May to be a basic app... or custom packages
-	if grep -qs 'Gmail\|Google\|Google+ for G Suite\|Hangouts\|YouTube\|Gboard\|Contacts\|Phone\|Google Photos\|Clock\|Google Camera\|Google Duo\|Dropbox\|Pushbullet\|Google Calendar\|Google Keep\|Telegram\|SwiftKey Keyboard\|Google Translate\|Facebook\|Pandora\|Twitter\|Slack\|MEGA\|WhatsApp Messenger\|Google Voice\|Google Drive\|Netflix\|Pixel Launcher\|Wallpapers\|GoPro\|Google VR Services\|Google Play services\|Carrier Services' "$MAGMOD/$TOADD.txt"; then
-		CHECK_RESULT_BASICS=1
-	fi
-	
-	WEB_NAME=$(cat "$MAGMOD/$TOADD.txt")
-		
-	if [ "$CHECK_RESULT_BASICS" == 1 ]; then
-		# For basic
-		# Get line number of app to hide from basic list
-		BASIC_NUMBER=$(grep -no "$TOADD" "$CONF" | sed 's/:.*//')
-		echo -e "\n- Enable $TOADD in your Detach.txt file as Common app\n"; sleep 2;
-		sed -i -e "${BASIC_NUMBER}s/# ${TOADD}/${TOADD}/" "$CONF"
-		
-		# Grep each sqlite commands with apps titles (common apps)
-		sqlite_cmds_common=$(grep -no '# Custom Packages' "$SERVICESH" | sed 's/:.*//')
-		sqlite_cmds_final=$((sqlite_cmds_common-1))
-		sqlite_cmds_cust=$(grep -n '# Multiple' "$SERVICESH" | sed 's/:.*//')
-		sqlite_cmds_final2=$((sqlite_cmds_cust-1))
-		sed "32,$sqlite_cmds_final!d;" "$SERVICESH" | grep '[a-zA-Z0-9]' >> "$ACT_BASIC_APPS"
-		sed "$sqlite_cmds_common,$sqlite_cmds_final2!d;" "$SERVICESH" | grep '[a-zA-Z0-9]' >> "$ACT_CUST_APPS"
-		echo -e "\n	# $BASIC_NAME_LOCAL\n	./sqlite \$PLAY_DB_DIR/library.db \"UPDATE ownership SET library_id = 'u-wl' where doc_id = '$i'\";\n\n$TOADD\n" >> "$ACT_BASIC_APPS"
-		
-		sed -i -e '32,$d' "$SERVICESH"
-		cat "$ACT_BASIC_APPS" >> "$SERVICESH"
-		echo -e "\n\n" >> "$SERVICESH"
-		cat "$ACT_CUST_APPS" >> "$SERVICESH"
-		# Export sqlite cmds before writing all other contents in file (for Instant Run step)
-		su -c grep sqlite "$SERVICESH" | sed -i -e '1d' >> "$Instant_sqlite"
-		cat "$COMPATIBILITY" >> "$SERVICESH"
-		#echo -e "\n\n# Exit\n	exit; fi\ndone &)\n" >> "$SERVICESH"
-		echo -e "\n\n# Exit\ndone &)\n" >> "$SERVICESH"
-	else
-		# For custom
-		# Grep each sqlite commands with apps titles (common apps)
-		sqlite_cmds_common=$(grep -no '# Custom Packages' "$SERVICESH" | sed 's/:.*//')
-		sqlite_cmds_final=$((sqlite_cmds_common-1))
-		sqlite_cmds_cust=$(grep -n '# Multiple' "$SERVICESH" | sed 's/:.*//')
-		sqlite_cmds_final2=$((sqlite_cmds_cust-1))
-		
-		sed "32,$sqlite_cmds_final!d;" "$SERVICESH" | grep '[a-zA-Z0-9]' >> "$ACT_BASIC_APPS"
-		sed "$sqlite_cmds_final,$sqlite_cmds_final2!d;" "$SERVICESH" | grep '[a-zA-Z0-9]' >> "$ACT_CUST_APPS"
-		echo "" >> "$ACT_CUST_APPS"
-		echo -e "\n	# $WEB_NAME\n	./sqlite \$PLAY_DB_DIR/library.db \"UPDATE ownership SET library_id = 'u-wl' where doc_id = '$TOADD'\";\n\n" >> "$ACT_CUST_APPS"
-		echo "" >> "$ACT_CUST_APPS"
-		sed -i -e '32,$d' "$SERVICESH"
-		cat "$ACT_BASIC_APPS" >> "$SERVICESH"
-		echo -e "\n\n" >> "$SERVICESH"
-		cat "$ACT_CUST_APPS" >> "$SERVICESH"
-		cat "$COMPATIBILITY" >> "$SERVICESH"
-		#echo -e "\n\n# Exit\n	exit; fi\ndone &)\n" >> "$SERVICESH"
-		echo -e "\n\n# Exit\ndone &)\n" >> "$SERVICESH"
-		echo -e $G"\n- Enable $WEB_NAME in your $CONF file.\n"$N
-		echo -e "$TOADD" >> "$CONF"
-	fi
-	
-	# Removing any existant backup(s) of specified app
-	ls -A1 "$MODPATH/Backup_${TOADD}*.txt" 2>/dev/null | xargs rm -f
-	
-	# Backup DB file specific datas before magic things..
-	$MAGMOD/sqlite "$PS_DATA_PATH" "SELECT * FROM ownership WHERE doc_id = '$line'" >> "$TMPDIR/Backup_$TOADD_${date +"%Y_%m_%d"}.txt"
-		
-		
-	# Instant Run
-	instant_run=$MAGMOD/instant_run.sh
-	instant_run_two=$MAGMOD/instant_run_two.sh
-	
-	test -e "$instant_run" || touch "$instant_run"
-	chmod 0777 "$instant_run" && chmod +x "$instant_run"
-	
-	PS_DATA_PATH=/data/data/com.android.vending/databases/library.db
-	
-	# Multiple Play Store accounts compatibility
-	ps_accounts=$("$MAGMOD/sqlite" $PS_DATA_PATH "SELECT account FROM ownership" | sort -u | wc -l)
-	ps_accounts_final=$((ps_accounts+1))
-	
-	cat /dev/null > "$instant_run"
-	echo -e "PLAY_DB_DIR=/data/data/com.android.vending/databases\nSQLITE=${MAGMOD}\n\n\nam force-stop com.android.vending\n\ncd \$SQLITE\n\n" >> "$instant_run"
-	
-	egrep "^[[:space:]]*./sqlite" "$SERVICESH" >> "$instant_run"
+		if [ $(echo "$TOADD" | wc -l) -gt 1 ]; then
+			echo -e $R"\n! Please enter only one package name at a time."$N; sleep 3;
+			exit
+		fi
 
-	echo "" >> "$instant_run"
-
-	test -e "$MAGMOD/first_detach_result.txt" || touch "$MAGMOD/first_detach_result.txt"
-	chmod 0644 "$MAGMOD/first_detach_result.txt"
-	sh "$instant_run" > "$MAGMOD/first_detach_result.txt" 2>&1
-
-	if [ "$ps_accounts" -gt "1" ]; then
-		test -e "$instant_run_two" || touch "$instant_run_two"
-		chmod 0644 "$instant_run_two"
-		echo -e "PLAY_DB_DIR=/data/data/com.android.vending/databases\nSQLITE=${MAGMOD}\n\n\nam force-stop com.android.vending\n\ncd \$SQLITE\n\n" > "$instant_run_two"
-		am force-stop com.android.vending
-		for i in {1..${ps_accounts_final}}; do grep sqlite "$instant_run" > "$instant_run_two"; done
-		sed -i -e 's/.\t\/sqlite/.\/sqlite/' "$instant_run_two"
-		sed -i -e 's/..\/sqlite/.\/sqlite/' "$instant_run_two"
-		sed -i -e "s/SQLITE=\$MODDIR.\/sqlite//" "$instant_run_two"
-		echo -e '\n' >> "$instant_run_two"
-	
-		sh "$instant_run_two" > "$MAGMOD/second_detach_result.txt" 2>&1
-	fi
-
-	wrong_result=$(echo "Error: UNIQUE constraint failed: ownership.account,")
+		case $CONFIRMADD in
+			Y|y|Yes|yes|YES)
+			echo -e $G"\nCheck if $TOADD exist on the Play Store..."$N; sleep 1;
 			
-	if grep "$wrong_result" "$MAGMOD/first_detach_result.txt"; then
-		[ -e "$MAGMOD/silent" ] || echo -e $C"\nDatabase file corrupted\nDatabase file need to be fixed, so please wait some little seconds...\n"$N; sleep 1;
-		ACTAPPS=$MAGMOD/actapps.txt
-		ACTAPPSBCK=$MAGMOD/actapps.bak
-		FINAL=$MAGMOD/final.sh
-		for o in "$ACTAPPS" "$ACTAPPSBCK" "$FINAL"; do touch "$o" && cat /dev/null > "$o" && chmod 0644 "$o"; done
-		grep sqlite "$instant_exit_final" > "$ACTAPPS"
-		sed -i -e "s/.\/sqlite \$PLAY_DB_DIR\/library.db \"UPDATE ownership SET library_id = 'u-wl' where doc_id = '//" -i -e "s/'\";//" "$ACTAPPS"
-		sed -i -e '1d' "$ACTAPPS"
-		sed -i -e 's/[[:blank:]]*//' "$ACTAPPS"
-		PLAY_DB_DIR=/data/data/com.android.vending/databases
-		cp -f "$ACTAPPS" "$ACTAPPSBCK"
-		echo -e "PLAY_DB_DIR=/data/data/com.android.vending/databases\nSQLITE=${MAGMOD}\n\n\nam force-stop com.android.vending\n\ncd \$SQLITE\n\n" >> "$FINAL"
-		
-		var_ACTAPPS=$(awk '{ print }' "$ACTAPPSBCK")
-		for i in $(echo "$var_ACTAPPS"); do echo -e "$MAGMOD/sqlite $PLAY_DB_DIR/library.db \"DELETE FROM ownership WHERE doc_id = '$i' AND library_id = '3'\";" >> "$FINAL"; done
-		sh "$FINAL"
-		am force-stop com.android.vending
+			# Check if user input exist on Play Store \(WIFI and/or LTE are require\)
+			
+			if wget --no-check-certificate -q "https://play.google.com/store/apps/details?id=${TOADD}&hl=en" -O /dev/null 2>&1 ; then
+				#echo "URL : $URL exists..."
+				#check if we already have it in our detach file
+				pkgName=$(grep -wr "$TOADD" $applist | cut -d, -f2 | grep . || echo "N/A")
+
+				if [ "$pkgName" != "N/A" ]; then
+					#remove # infron of app name
+					#get line number in detach.txt
+					BASIC_NUMBER=$(sed 's/^#//g' "$CONF" | grep -no "$pkgName" | cut -f1 -d: | sort -u)	
+					echo -e  $G"\n- Uncomment $pkgName in your $CONF file\n"$N; sleep 2;
+					sed -i -e "${BASIC_NUMBER}s/#${pkgName}/${pkgName}/" "$CONF"
+
+				else
+					#result not found
+					#only add if not available
+					echo -e  $G"\n- Enable $TOADD in your $CONF file as Common app\n"$N; sleep 2;
+					grep -qF -- "$TOADD" "$CONF" || echo "$TOADD" >> "$CONF"
+				fi
 					
-		echo -e $G"\nDetaching task done\n"$N
-	else		
-		echo -e $G"\nDone\n"$N
-	fi
-	
-	for f in "$ACTAPPS" "$ACTAPPSBCK" "$MAGMOD/second_detach_result.txt" "$instant_run_two"; do rm -f "$f"; done
-;;
-	N|n|No|no|NO) echo $R"\nCanceled\n"$N
-	exit 0
+				# Just paste after last match of $SQLITE/sqlite \\t is for tab
+				app_name="\$SQLITE/sqlite \$PLAY_DB_DIR/library.db \"UPDATE ownership SET library_id = 'u-wl' where doc_id = '$TOADD'\";"
+				grep -qF -- "$app_name" "$SERVICESH" || sed -i -e "$(grep -n '^[[:blank:]]*$SQLITE/sqlite' $SERVICESH |tail -1|cut -f1 -d':')a \\n \\t $app_name" "$SERVICESH"
 				
-;;
-	*) echo $R"\n\nINVALID ENTRY, try again.\n"$N
-;;
-esac
-#stop coping to sdcard
-#cp -f "$instant_run" /sdcard
+				sh $servicefile
+			else
+				#echo "URL : $URL doesn't exists.."
+				echo -e "\nWarning: The package name of the application you just\nentered does not exist in the Play Store.\n"
+				rm -rf "$ACT_BASIC_APPS"
+				rm -rf "$ACT_CUST_APPS"
+				rm -rf "$instant_run"
+				rm -rf "$Instant_sqlite"
+				exit
+			fi
 
-	
-rm -f "$ACT_BASIC_APPS"
-rm -f "$ACT_CUST_APPS"
-#rm -f "$instant_run"
-rm -f "$Instant_sqlite"
-rm -f "$MAGMOD/first_detach_result.txt"
-rm -f $MAGMOD/*.html
-rm -f "$MAGMOD/DL_check.txt"
-rm -f "$MAGMOD/$TOADD.txt"
+			# Removing any existant backup(s) of specified app
+			ls -A1 "$MAGMOD/Backup_${TOADD}*.txt" 2>/dev/null | xargs rm -f
+			
+			
+			# Backup DB file specific datas before magic things..
+			#$MAGMOD/sqlite "$PS_DATA_PATH" "SELECT * FROM ownership WHERE doc_id = '$line'" >> "$TMPDIR/Backup_$TOADD_${backup_txt}.txt"
+		
+			
+			# Instant Run
+			instant_run=$MAGMOD/instant_run.sh
+			instant_run_two=$MAGMOD/instant_run_two.sh
+			
+			test -e "$instant_run" || touch "$instant_run"
+			chmod 0777 "$instant_run" && chmod +x "$instant_run"
+			
+			# Multiple Play Store accounts compatibility
+			ps_accounts=$("$MAGMOD/sqlite" $PS_DATA_PATH "SELECT account FROM ownership" | sort -u | wc -l)
+			ps_accounts_final=$((ps_accounts+1))
+			
+			cat /dev/null > "$instant_run"
+			echo -e "PLAY_DB_DIR=/data/data/com.android.vending/databases\nSQLITE=${MAGMOD}\n\n\nam force-stop com.android.vending\n\ncd \$SQLITE\nSleep 1;\n" >> "$instant_run"
+			
+			#not needed as passing whole path
+			sed -n '/^\s*$SQLITE\/sqlite.*/p' "$SERVICESH" >> "$instant_run"
+			#egrep "^[[:space:]]*$SQLITE/sqlite" "$SERVICESH" >> "$instant_run"
+			
+			echo "" >> "$instant_run"
 
-	# Selinux statut restoring
-case "$SELINUX_STATUT" in
-	Enforcing) setenforce 1
-	;;
-	Permissive) setenforce 0
-	;;
-esac
+			test -e "$MAGMOD/first_detach_result.txt" || touch "$MAGMOD/first_detach_result.txt"
+			chmod 0644 "$MAGMOD/first_detach_result.txt"
+			sh "$instant_run" > "$MAGMOD/first_detach_result.txt" 2>&1
+
+			if [ "$ps_accounts" -gt "1" ]; then
+				test -e "$instant_run_two" || touch "$instant_run_two"
+				chmod 0644 "$instant_run_two"
+				echo -e "PLAY_DB_DIR=/data/data/com.android.vending/databases\nSQLITE=${MAGMOD}\n\n\nam force-stop com.android.vending\n\ncd \$SQLITE\nSleep 1;\n" > "$instant_run_two"
+				am force-stop com.android.vending
+				sleep 1;
+				for i in {1..${ps_accounts_final}}; do sed -n '/^\s*$SQLITE\/sqlite.*/p' "$instant_run" >> "$instant_run_two"; done
+				#sed -i -e "s/.$(echo a | tr 'a' '\t')\/sqlite/$SQLITE\/sqlite/" "$instant_run_two"
+				#sed -i -e 's/..\/sqlite/$SQLITE\/sqlite/' "$instant_run_two"
+				#sed -i -e 's/.\/sqlite/$SQLITE\/sqlite/' "$instant_run_two"
+				echo -e '\n' >> "$instant_run_two"
+			
+				sh "$instant_run_two" > "$MAGMOD/second_detach_result.txt" 2>&1
+			fi
+
+			wrong_result=$(echo "Error: UNIQUE constraint failed: ownership.account,")
+					
+			if grep "$wrong_result" "$MAGMOD/first_detach_result.txt"; then
+				[ -e "$MAGMOD/silent" ] || echo -e $C"\nDatabase file corrupted\nDatabase file need to be fixed, so please wait some little seconds...\n"$N; sleep 1;
+				ACTAPPS=$MAGMOD/actapps.txt
+				ACTAPPSBCK=$MAGMOD/actapps.bak
+				FINAL=$MAGMOD/final.sh
+				for o in "$ACTAPPS" "$ACTAPPSBCK" "$FINAL"; do touch "$o" && cat /dev/null > "$o" && chmod 0644 "$o"; done
+				#grep sqlite "$MODDIR/instant_exist_final.txt" > "$ACTAPPS"
+				sed -i -e "s/\$SQLITE\/sqlite \$PLAY_DB_DIR\/library.db \"UPDATE ownership SET library_id = 'u-wl' where doc_id = '//" -i -e "s/'\";//" "$ACTAPPS"
+				sed -i -e '1d' "$ACTAPPS"
+				sed -i -e 's/[[:blank:]]*//' "$ACTAPPS"
+				PLAY_DB_DIR=/data/data/com.android.vending/databases
+				cp -f "$ACTAPPS" "$ACTAPPSBCK"
+				echo -e "PLAY_DB_DIR=/data/data/com.android.vending/databases\nSQLITE=${MAGMOD}\n\n\nam force-stop com.android.vending\n\ncd \$SQLITE\nSleep 1;\n" >> "$FINAL"
+				
+				var_ACTAPPS=$(awk '{ print }' "$ACTAPPSBCK")
+				for i in $(echo "$var_ACTAPPS"); do echo -e "$MAGMOD/sqlite $PLAY_DB_DIR/library.db \"DELETE FROM ownership WHERE doc_id = '$i' AND library_id = '3'\";" >> "$FINAL"; done
+				sh "$FINAL"
+				am force-stop com.android.vending
+							
+				echo -e $G"\nDetaching task done\n"$N
+			else		
+				echo -e $G"\nDone\n"$N
+			fi
+			
+			for f in "$ACTAPPS" "$ACTAPPSBCK" "$MAGMOD/second_detach_result.txt" "$instant_run_two"; do rm -f "$f"; done
+		;;
+			N|n|No|no|NO) echo $R"\nCanceled\n"$N
+			exit 0
+						
+		;;
+			*) echo $R"\n\nINVALID ENTRY, try again.\n"$N
+		;;
+		esac
+		#stop coping to sdcard
+		#cp -f "$instant_run" /sdcard
+
+			
+		rm -rf "$ACT_BASIC_APPS"
+		rm -rf "$ACT_CUST_APPS"
+		rm -rf "$instant_run"
+		rm -f "$Instant_sqlite"
+		rm -rf "$MAGMOD/first_detach_result.txt"
+		rm -rf "$MAGMOD/DL_check.txt"
+		rm -rf "$MAGMOD/$TOADD.txt"
+
+			# Selinux statut restoring
+		case "$SELINUX_STATUT" in
+			Enforcing) setenforce 1
+			;;
+			Permissive) setenforce 0
+			;;
+		esac
+
+ else
+		echo -e $Y"You will need internet connecton for this option!"$N
+		exit
+ fi
+ 
 }
 
 
@@ -452,8 +427,9 @@ chmod 0644 "$ACTAPPS"
 
 PS_DATA_PATH=/data/data/com.android.vending/databases/library.db
 
-egrep "^[[:space:]]*./sqlite" "$SERVICESH" >> "$ACTAPPS"
-sed -i -e "s/.\/sqlite \$PLAY_DB_DIR\/library.db \"UPDATE ownership SET library_id = 'u-wl' where doc_id = '//" -i -e "s/'\";//" "$ACTAPPS"
+#egrep "^[[:space:]]*$SQLITE/sqlite" "$SERVICESH" >> "$ACTAPPS"
+sed -n '/^\s*$SQLITE\/sqlite.*/p' "$SERVICESH" >> "$instant_run"
+sed -i -e "s/\$SQLITE\/sqlite \$PLAY_DB_DIR\/library.db \"UPDATE ownership SET library_id = 'u-wl' where doc_id = '//" -i -e "s/'\";//" "$ACTAPPS"
 sed -i -e 's/[ \t]*//' "$ACTAPPS"
 
 
@@ -493,7 +469,7 @@ case $CONFTODEL in
 			# Import data (extracted from DB file during module setup) to DB file
 			# Check
 			echo -e $C"\n\n=> Searching for backups...\n\n"$N; sleep 1;
-			ls | grep "^Backup_${APPLINE2REM}_*\.csv$" "$MAGMOD" >> "$MODPATH/DB_BCK_CHECK.txt"
+			ls | grep "^Backup_${APPLINE2REM}_*\.csv$" "$MAGMOD" >> "$MAGMOD/DB_BCK_CHECK.txt"
 			if [ -z "$DB_BCK_CHECK"  ]; then
 				echo -e $R"\n\n ! No backup found, your app will appear again in you Play Store app when it will refresh it's database file.\n\n"$N; sleep 3; exit ;
 			fi
@@ -501,21 +477,21 @@ case $CONFTODEL in
 				echo -e $R"\n\n=> Removing old backup(s)...\n\n"$N; sleep 2;
 				
 				# Search all backup(s) for the specific app and delete it/them
-				ls -A1 "$MODPATH/Backup_$APPLINE2REM*.csv" | sed -n '1!p' | xargs rm -f
+				ls -A1 "$MAGMOD/Backup_$APPLINE2REM*.csv" | sed -n '1!p' | xargs rm -f
 			fi
 			echo -e $C"\n\n=> Restoring the last backup...\n\n"$N; sleep 1;
-			BCK_TO_RESTORE=$(ls -A1 "$MODPATH/Backup_$APPLINE2REM*.csv")
+			BCK_TO_RESTORE=$(ls -A1 "$MAGMOD/Backup_$APPLINE2REM*.csv")
 			
 			# Restore backup data to DB File
 			tableName=$(head -n 1 /sdcard/a.csv | sed 's/,/;/g')
-			DATAS_DB=$("$MODPATH/sqlite" /sdcard/library.db "SELECT * FROM ownership WHERE doc_id = '$APPLINE2REM';")
+			DATAS_DB=$("$MAGMOD/sqlite" /sdcard/library.db "SELECT * FROM ownership WHERE doc_id = '$APPLINE2REM';")
 			
 			sed -i -e '1d' "$BCK_TO_RESTORE"
-			(echo .separator ";"; echo .import "$BCK_TO_RESTORE" ownership) | "$MODPATH/sqlite" "$PS_DATA_PATH"
+			(echo .separator ";"; echo .import "$BCK_TO_RESTORE" ownership) | "$MAGMOD/sqlite" "$PS_DATA_PATH"
 
 			for name in "$tableName";
 				do if [ $($echo "$DATAS_DB") -eq "$APPLINE2REM" ]; then
-					"$MODPATH/sqlite" /sdcard/library.db "UPDATE ownership SET "$name" = null WHERE "$name" = '';"
+					"$MAGMOD/sqlite" /sdcard/library.db "UPDATE ownership SET "$name" = null WHERE "$name" = '';"
 				fi
 			done
 			
@@ -870,7 +846,7 @@ WriteSchedule () {
 	#Create crons file if not available
 	test -e "$cronsfile" || touch "$cronsfile"
 	#echo "0,30 * * * * detach -id" > "$cronsfile"
-	echo "$1 detach -id" > "$cronsfile"
+	echo "$1 su -c detach -id" > "$cronsfile"
 	chmod 0755 "$cronsfile" && chmod +x "$cronsfile"
 			
 	#Execute


### PR DESCRIPTION
Because of this line `#sh "$MAGMOD/main.sh" > "$MAGMOD/first_detach_result.txt" 2>&1` in `compatibility.txt`, the `service.sh` file was running in infinite loop. So to mitigate the issue I created a separate `sh` file named `main.sh` which will be called by `service.sh` only once. I have tested this changes few times now and seems to work good. But need additional testing.